### PR TITLE
Adding support for building docs on ReadTheDocs

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,0 +1,17 @@
+name: theano-docs
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.7
+  - gcc_linux-64
+  - gxx_linux-64
+  - numpy
+  - scipy
+  - six
+  - sphinx>=3
+  - sphinx_rtd_theme
+  - mock
+  - pillow
+  - pip:
+    - -e ..[doc]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+version: 2
+sphinx:
+  configuration: doc/conf.py
+conda:
+  environment: doc/environment.yml


### PR DESCRIPTION
This pull request adds support for automatically building the documentation on ReadTheDocs. It looks like it's working, but I'd love to get another set of eyes on it to look for missing pages.

You can take a look at the build docs here: https://theano-pymc-test.readthedocs.io/en/readthedocs/