### PR TITLE
Fixing ResourceWarning on macOS

### DIFF
--- a/theano/misc/cpucount.py
+++ b/theano/misc/cpucount.py
@@ -32,12 +32,18 @@
 
 import os
 import sys
+import multiprocessing
 
 
 def cpuCount():
     """
     Returns the number of CPUs in the system
     """
+    try:
+        return multiprocessing.cpu_count()
+    except NotImplementedError:
+        pass
+
     if sys.platform == "win32":
         try:
             num = int(os.environ["NUMBER_OF_PROCESSORS"])

--- a/theano/misc/cpucount.py
+++ b/theano/misc/cpucount.py
@@ -26,12 +26,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 #
 
-# This function was modified from the original code
-# We can't use the multiprocessing module as it was included in python2.6
-# and we support python 2.4
-
-import os
-import sys
 import multiprocessing
 
 
@@ -42,22 +36,4 @@ def cpuCount():
     try:
         return multiprocessing.cpu_count()
     except NotImplementedError:
-        pass
-
-    if sys.platform == "win32":
-        try:
-            num = int(os.environ["NUMBER_OF_PROCESSORS"])
-        except (ValueError, KeyError):
-            num = -1
-    elif sys.platform == "darwin":
-        try:
-            num = int(os.popen("sysctl -n hw.ncpu").read())
-        except ValueError:
-            num = -1
-    else:
-        try:
-            num = os.sysconf("SC_NPROCESSORS_ONLN")
-        except (ValueError, OSError, AttributeError):
-            num = -1
-
-    return num
+        return -1


### PR DESCRIPTION
Recently Theano has started emitting a `ResourceWarning` on import on macOS. This can be reproduced by running the following:

```bash
python -Werror::ResourceWarning -c 'import theano'
```

in a clean environment with the GitHub version of Theano-PyMC on macOS. This will produce the following error:

```python
Traceback (most recent call last):
  File "/Users/dforeman/miniconda3/envs/theano/lib/python3.8/subprocess.py", line 942, in __del__
    _warn("subprocess %s is still running" % self.pid,
ResourceWarning: subprocess 56159 is still running
Exception ignored in: <_io.FileIO name=4 mode='rb' closefd=True>
Traceback (most recent call last):
  File "/Users/dforeman/src/pymc-devs/Theano-PyMC/theano/misc/cpucount.py", line 48, in cpuCount
    num = int(os.popen("sysctl -n hw.ncpu").read())
ResourceWarning: unclosed file <_io.TextIOWrapper name=4 encoding='UTF-8'>
```

This pull request simplifies the `cpuCount` code which I think is fine since we don't support Python 2.4 anymore :D 