### PR TITLE
Don't run coveralls after style checks in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
   - "3.6"
 
 stages:
-  - lint
+  - style-checks
   - test
 
 env:
@@ -67,10 +67,11 @@ install:
 
 jobs:
   include:
-    - stage: lint
+    - stage: style-checks
       script:
         - black -t py36 --check theano/ tests/ setup.py
         - flake8
+      after_success: skip
     - &normaltest
       stage: test
       env: FAST_COMPILE=1 FLOAT32=1 PART="tests --ignore=tests/tensor/nnet --ignore=tests/tensor/signal"


### PR DESCRIPTION
This PR removes the unnecessary (and probably confounding) step of running `coveralls` after the linting/style checking job in Travis.