### PR TITLE
Add a test for jax conversion of theano.scalar.basic.Identity

### DIFF
--- a/tests/sandbox/test_jax.py
+++ b/tests/sandbox/test_jax.py
@@ -538,3 +538,12 @@ def test_arange():
     out = tt.arange(a)
     fgraph = theano.gof.FunctionGraph([a], [out])
     _ = compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+
+
+def test_identity():
+    a = tt.scalar("a")
+    a.tag.test_value = 10
+
+    out = theano.scalar.basic.identity(a)
+    fgraph = theano.gof.FunctionGraph([a], [out])
+    _ = compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])


### PR DESCRIPTION
This PR simply adds a test for JAX conversion of `theano.scalar.basic.Identity`.