### PR TITLE
Adding action to publish to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,51 @@
+name: PyPI
+on:
+  push:
+    branches:
+      - master
+      - auto-release
+  pull_request:
+    branches: [master]
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Build the sdist
+        run: |
+          python setup.py sdist
+      - name: Check the sdist installs and imports
+        run: |
+          mkdir -p test-sdist
+          cd test-sdist
+          python -m venv venv-sdist
+          venv-sdist/bin/python -m pip install ../dist/Theano-PyMC-*.tar.gz
+          venv-sdist/bin/python -c "import theano;print(theano.__version__)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: artifact
+          path: dist/*
+
+  upload_pypi:
+    name: Upload to PyPI on release
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_secret }}


### PR DESCRIPTION
Ready for review.

Ref: #77 

The workflow for this is that it'll build the sdist on every push and pull request to make sure that that builds and imports properly. Then, on a published release, it would upload the sdist to PyPI using the (currently non-existent) `pypi_password` repo secret (set to a PyPI token with the Theano project scope). This workflow could be adjusted!

(There are also some formatting fixes for the main test action. I can remove those if requested, but I don't think it'll hurt to merge them from here.)