### PR TITLE
Add cumop jaxification

### DIFF
--- a/tests/sandbox/test_jax.py
+++ b/tests/sandbox/test_jax.py
@@ -102,12 +102,12 @@ def test_jax_compile_ops():
     x = theano.compile.ops.Shape()(tt.as_tensor_variable(x_np))
     x_fg = theano.gof.FunctionGraph([], [x])
 
-    compare_jax_and_py(x_fg, [])
+    compare_jax_and_py(x_fg, [], must_be_device_array=False)
 
     x = theano.compile.ops.Shape_i(1)(tt.as_tensor_variable(x_np))
     x_fg = theano.gof.FunctionGraph([], [x])
 
-    compare_jax_and_py(x_fg, [])
+    compare_jax_and_py(x_fg, [], must_be_device_array=False)
 
     x = theano.compile.ops.SpecifyShape()(tt.as_tensor_variable(x_np), (20, 3))
     x_fg = theano.gof.FunctionGraph([], [x])

--- a/tests/sandbox/test_jax.py
+++ b/tests/sandbox/test_jax.py
@@ -424,6 +424,8 @@ def test_jax_IncSubtensor():
 
 def test_jax_ifelse():
 
+    import theano.ifelse
+
     true_vals = np.r_[1, 2, 3]
     false_vals = np.r_[-1, -2, -3]
 

--- a/tests/sandbox/test_jax.py
+++ b/tests/sandbox/test_jax.py
@@ -354,7 +354,7 @@ def test_jax_Subtensors():
 
 
 def test_jax_IncSubtensor():
-    x_np = np.empty((3, 4, 5), dtype=tt.config.floatX)
+    x_np = np.random.uniform(-1, 1, size=(3, 4, 5)).astype(tt.config.floatX)
     x_tt = tt.arange(3 * 4 * 5).reshape((3, 4, 5)).astype(tt.config.floatX)
 
     # "Set" basic indices

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -1065,13 +1065,10 @@ class TestUnravelIndex(utt.InferShapeTester):
             indices_symb = theano.shared(indices)
 
             # reference result
-            ref = np.unravel_index(indices, shape)
+            ref = np.unravel_index(indices, shape, order=order)
 
-            def fn(i, d, nd=None):
-                if nd is None:
-                    return function([], unravel_index(i, d, order=order))
-                else:
-                    return function([], unravel_index(i, d, order=order, ndim=nd))
+            def fn(i, d):
+                return function([], unravel_index(i, d, order=order))
 
             # shape given as a tuple
             f_array_tuple = fn(indices, shape)
@@ -1086,7 +1083,7 @@ class TestUnravelIndex(utt.InferShapeTester):
 
             # shape given as a theano variable
             shape_symb = theano.shared(shape_array)
-            f_array_symb = fn(indices, shape_symb, len(shape))
+            f_array_symb = fn(indices, shape_symb)
             np.testing.assert_equal(ref, f_array_symb())
 
             # shape given as a Shape op (unravel_index will use get_vector_length
@@ -1098,7 +1095,7 @@ class TestUnravelIndex(utt.InferShapeTester):
             # shape testing
             self._compile_and_check(
                 [],
-                unravel_index(indices, shape_symb, order=order, ndim=len(shape)),
+                unravel_index(indices, shape_symb, order=order),
                 [],
                 UnravelIndex,
             )
@@ -1118,8 +1115,6 @@ class TestUnravelIndex(utt.InferShapeTester):
             unravel_index(theano.tensor.fvector(), (3, 4))
         with pytest.raises(TypeError):
             unravel_index((3, 4), (3.4, 3.2))
-        with pytest.raises(ValueError):
-            unravel_index((3, 4), (3, 3), ndim=5.4)
 
         # dims must be a 1D sequence
         with pytest.raises(TypeError):

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -5002,6 +5002,8 @@ def get_vector_length(v):
         raise TypeError("argument must be symbolic vector, got '%s'" % v)
     if v.type.broadcastable[0]:
         return 1
+    if isinstance(v, theano.tensor.sharedvar.TensorSharedVariable) and v.type.ndim == 1:
+        return len(v.get_value())
     if isinstance(v, gof.Constant) and v.type.ndim == 1:
         return len(v.data)
     if v.owner and isinstance(v.owner.op, theano.tensor.opt.MakeVector):

--- a/theano/tensor/extra_ops.py
+++ b/theano/tensor/extra_ops.py
@@ -294,7 +294,10 @@ class CumOp(theano.Op):
     def perform(self, node, inputs, output_storage, params):
         x = inputs[0]
         z = output_storage[0]
-        z[0] = {"add": np.cumsum, "mul": np.cumprod}[self.mode](x, axis=self.axis)
+        if self.mode == "add":
+            z[0] = np.cumsum(x, axis=self.axis)
+        else:
+            z[0] = np.cumprod(x, axis=self.axis)
 
     def grad(self, inputs, output_gradients):
         (x,) = inputs


### PR DESCRIPTION
This PR adds more JAX `Op` conversions from `theano.tensor.extra_ops`.  It also fixes the general JAX linker testing framework by removing *all* optimizations, so that more `Op`s are included and none are unexpectedly removed.