### PR TITLE
Prevent CI from running Python tests for non-Python changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,22 @@ on:
   push:
     branches:
       - master
+      - gh-actions
+    paths:
+      - 'setup.cfg'
+      - 'requirements.txt'
+      - '.coveragerc'
+      - '**.py'
+      - '!docs/**'
   pull_request:
     branches:
       - master
+    paths:
+      - 'setup.cfg'
+      - 'requirements.txt'
+      - '.coveragerc'
+      - '**.py'
+      - '!docs/**'
 
 jobs:
   style:


### PR DESCRIPTION
The changes in the PR prevent CI from running when only non-Python files are changed.  It also attempts to set up Conda and `pip` requirements caching.