### PR TITLE
Combining checks into one and dealing with skipped runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: true
 
+      - name: Get unique id
+        id: unique-id
+        env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+        run: |
+          echo $STRATEGY_CONTEXT
+          export JOB_ID=`echo $STRATEGY_CONTEXT | md5sum`
+          echo $JOB_ID
+          echo "::set-output name=id::$JOB_ID"
+
       # Setup
       - name: Install dependencies
         shell: bash -l {0}
@@ -138,19 +148,13 @@ jobs:
           FAST_COMPILE: ${{ matrix.fast-compile }}
           FLOAT32: ${{ matrix.float32 }}
 
-      - name: Coverage
-        shell: bash -l {0}
-        run: |
-          echo $COVERALLS_FLAG_NAME
-          python -m pip install coveralls
-          coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: "py${{ matrix.python-version }} (${{ matrix.fast-compile }}-${{ matrix.float32 }}): ${{ matrix.part }}"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.unique-id.outputs.id }}
+          path: .coverage
 
   coverage:
-    name: "Upload coverage"
+    name: "Merge and upload coverage"
     needs: test
     runs-on: ubuntu-latest
     if: ${{ needs.test.result == 'success' }}
@@ -162,10 +166,13 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
-      - name: Coveralls Finished
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+      - name: Merge and upload coverage
         run: |
           python -m pip install coveralls
-          coveralls --finish
+          find . -name \.coverage -exec coverage combine --append {} \;
+          coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,27 +4,41 @@ on:
   push:
     branches:
       - master
-      - gh-actions
-    paths:
-      - 'setup.cfg'
-      - 'requirements.txt'
-      - '.coveragerc'
-      - '**.py'
-      - '!docs/**'
+      - checks
   pull_request:
     branches:
       - master
-    paths:
-      - 'setup.cfg'
-      - 'requirements.txt'
-      - '.coveragerc'
-      - '**.py'
-      - '!docs/**'
 
 jobs:
-  style:
-    name: "Check code style"
+  changes:
+    name: "Check for changes"
     runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.changes.outputs.src }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            python: &python
+            - 'theano/**/*.py'
+            - 'tests/**/*.py'
+            - '*.py'
+            src:
+            - *python
+            - '.github/**/*.yml'
+            - 'setup.cfg'
+            - 'requirements.txt'
+            - '.coveragerc'
+
+  style:
+    name: Check code style
+    needs: changes
+    runs-on: ubuntu-latest
+    if: ${{ needs.changes.outputs.changes == 'true' }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -42,8 +56,11 @@ jobs:
 
   test:
     name: "Test py${{ matrix.python-version }}: ${{ matrix.part }}"
-    needs: style
+    needs:
+      - changes
+      - style
     runs-on: ubuntu-latest
+    if: ${{ needs.changes.outputs.changes == 'true' && needs.style.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -136,7 +153,11 @@ jobs:
     name: "Upload coverage"
     needs: test
     runs-on: ubuntu-latest
+    if: ${{ needs.test.result == 'success' }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -147,3 +168,13 @@ jobs:
           coveralls --finish
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
+
+  combine:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: "All tests"
+    needs: [changes, style, test]
+    steps:
+      - name: Check build matrix status
+        if: ${{ needs.changes.outputs.changes == 'true' && (needs.style.result != 'success' || needs.test.result != 'success') }}
+        run: exit 1


### PR DESCRIPTION
I believe that this will fix #87.

I'm finding that some of the jax tests are failing on my fork though:

`tests/sandbox/test_jax.py::test_extra_ops` fails with:

```
jax.core.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected.
```
