### PR TITLE
Fix exception handling in as_tensor_variable

### DIFF
--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -10,27 +10,20 @@ If you want to use a scalar variable in a Theano graph,
 you probably want to use theano.tensor.[c,z,f,d,b,w,i,l,]scalar!
 """
 
-
-from itertools import chain
 import math
 import warnings
 from copy import copy
+from functools import partial
+from itertools import chain
 from textwrap import dedent
 
 import numpy as np
 import six
-
-
 import theano
+from theano import config, gof, printing
 from theano.compat import Callable
-from theano import gof, printing
-from theano.gof import Op, utils, Variable, Constant, Type, Apply, FunctionGraph
-from functools import partial
-from theano import config
-
-from theano.gradient import DisconnectedType
-from theano.gradient import grad_undefined
-
+from theano.gof import Apply, Constant, FunctionGraph, Op, Type, Variable, utils
+from theano.gradient import DisconnectedType, grad_undefined
 from theano.printing import pprint
 
 builtin_bool = bool
@@ -267,9 +260,14 @@ class autocast_float_as(object):
 
 
 def convert(x, dtype=None):
-    """
-    Convert the input to a properly typed numpy value according to the
-    current casting policy.  Work with scalars and tensors.
+    """Convert the input to a properly typed NumPy value according to the current casting policy.
+
+    Parameters
+    ----------
+    x : Number, numpy.ndarray, or Sequence[Number]
+        The value(s) to be converted
+    dtype : str or numpy.dtype (optional)
+        The dtype to use for the conversion of `x`.
 
     """
     if dtype is not None:

--- a/theano/tensor/__init__.py
+++ b/theano/tensor/__init__.py
@@ -9,7 +9,6 @@ from theano.tensor.basic import *
 from theano.tensor.subtensor import *
 from theano.tensor.type_other import *
 from theano.tensor.var import (
-    AsTensorError,
     _tensor_py_operators,
     TensorVariable,
     TensorConstantSignature,

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -22,7 +22,6 @@ from theano.gof.type import Generic
 from theano.scalar import int32
 from theano.tensor import elemwise
 from theano.tensor.var import (
-    AsTensorError,
     TensorVariable,
     TensorConstant,
     _tensor_py_operators,
@@ -132,10 +131,7 @@ def as_tensor_variable(x, name=None, ndim=None):
 
     Raises
     ------
-    ValueError
-        If an `Apply` with more than one output is fetched or
-        if `x` cannot be made into a Variable with `ndim` dimensions.
-    AsTensorError
+    TypeError
         If `x` cannot be converted to a TensorType Variable.
 
     """
@@ -152,7 +148,7 @@ def as_tensor_variable(x, name=None, ndim=None):
     if isinstance(x, gof.Apply):
         # use Apply's default output mechanism
         if (x.op.default_output is None) and (len(x.outputs) != 1):
-            raise ValueError(
+            raise TypeError(
                 "Multi-output Op encountered. "
                 "Retry using only one of the outputs directly."
             )
@@ -168,7 +164,7 @@ def as_tensor_variable(x, name=None, ndim=None):
             x = tensor_from_scalar(x)
 
         if not isinstance(x.type, TensorType):
-            raise AsTensorError(
+            raise TypeError(
                 "Tensor type field must be a TensorType; found {}.".format(type(x.type))
             )
 
@@ -207,13 +203,10 @@ def as_tensor_variable(x, name=None, ndim=None):
         try:
             x = [extract_constants(i) for i in x]
         except TypeError:
-            try:
-                return stack(x)
-            except (TypeError, ValueError):
-                pass
+            return stack(x)
 
     elif isinstance(x, bool):
-        raise AsTensorError(
+        raise TypeError(
             "Cannot cast True or False as a tensor variable. Please use "
             "np.array(True) or np.array(False) if you need these constants. "
             "This error might be caused by using the == operator on "
@@ -221,12 +214,7 @@ def as_tensor_variable(x, name=None, ndim=None):
             "use theano.tensor.eq(v, w) instead."
         )
 
-    try:
-        return constant(x, name=name, ndim=ndim)
-    except TypeError:
-        raise AsTensorError(
-            "Cannot convert {} of type {} to TensorType".format(x, type(x))
-        )
+    return constant(x, name=name, ndim=ndim)
 
 
 # this has a different name, because _as_tensor_variable is the

--- a/theano/tensor/var.py
+++ b/theano/tensor/var.py
@@ -16,15 +16,6 @@ from theano.tensor.type import TensorType
 from theano import config
 
 
-class AsTensorError(TypeError):
-    """
-    Raised when as_tensor_variable isn't able to create a TensorVariable.
-
-    """
-
-    pass
-
-
 class _tensor_py_operators(object):
     def __abs__(self):
         return theano.tensor.basic.abs_(self)
@@ -117,7 +108,7 @@ class _tensor_py_operators(object):
         # Evidently, we need to catch NotImplementedError
         # TypeError from as_tensor_variable are caught in Elemwise.make_node
         # Oterwise TensorVariable * SparseVariable won't work!
-        except (NotImplementedError, AsTensorError):
+        except (NotImplementedError, TypeError):
             # We must return NotImplemented and not an
             # NotImplementedError or raise an NotImplementedError.
             # That way python will give a good error message like this
@@ -130,7 +121,7 @@ class _tensor_py_operators(object):
         # and the return value in that case
         try:
             return theano.tensor.basic.sub(self, other)
-        except (NotImplementedError, AsTensorError):
+        except (NotImplementedError, TypeError):
             return NotImplemented
 
     def __mul__(self, other):
@@ -138,7 +129,7 @@ class _tensor_py_operators(object):
         # and the return value in that case
         try:
             return theano.tensor.mul(self, other)
-        except (NotImplementedError, AsTensorError):
+        except (NotImplementedError, TypeError):
             return NotImplemented
 
     def __div__(self, other):
@@ -150,7 +141,7 @@ class _tensor_py_operators(object):
             # This is to raise the exception that occurs when trying to divide
             # two integer arrays (currently forbidden).
             raise
-        except (NotImplementedError, AsTensorError):
+        except (NotImplementedError, TypeError):
             return NotImplemented
 
     __truediv__ = __div__
@@ -160,7 +151,7 @@ class _tensor_py_operators(object):
         # and the return value in that case
         try:
             return theano.tensor.basic.pow(self, other)
-        except (NotImplementedError, AsTensorError):
+        except (NotImplementedError, TypeError):
             return NotImplemented
 
     def __mod__(self, other):
@@ -172,7 +163,7 @@ class _tensor_py_operators(object):
             # This is to raise the exception that occurs when trying to compute
             # x % y with either x or y a complex number.
             raise
-        except (NotImplementedError, AsTensorError):
+        except (NotImplementedError, TypeError):
             return NotImplemented
 
     def __divmod__(self, other):


### PR DESCRIPTION
This PR introduces changes that prevent downstream code (e.g. test value computation) from throwing exceptions (e.g. `ValueError`s) that break the logic in `theano.tensor.basic.as_tensor_variable`.
