### PR TITLE
Remove redundant AdvancedBoolean*Subtensor classes

### DIFF
--- a/tests/gpuarray/test_subtensor.py
+++ b/tests/gpuarray/test_subtensor.py
@@ -11,7 +11,6 @@ from theano.gpuarray.subtensor import (
     GpuSubtensor,
     GpuAdvancedSubtensor1,
     GpuAdvancedSubtensor,
-    GpuAdvancedBooleanSubtensor,
     GpuAdvancedIncSubtensor,
     GpuAdvancedIncSubtensor1,
     GpuAdvancedIncSubtensor1_dev20,
@@ -37,7 +36,6 @@ class TestGPUSubtensor(TestSubtensor):
         self.adv_sub1 = GpuAdvancedSubtensor1
         self.adv_incsub1 = GpuAdvancedIncSubtensor1
         self.adv_sub = GpuAdvancedSubtensor
-        self.adv_bool_sub = GpuAdvancedBooleanSubtensor
         self.dimshuffle = GpuDimShuffle
         self.mode = mode_with_gpu
         # avoid errors with limited devices
@@ -60,7 +58,6 @@ class TestGPUSubtensorF16(TestSubtensor):
         self.adv_sub1 = GpuAdvancedSubtensor1
         self.adv_incsub1 = GpuAdvancedIncSubtensor1
         self.adv_sub = GpuAdvancedSubtensor
-        self.adv_bool_sub = GpuAdvancedBooleanSubtensor
         self.dimshuffle = GpuDimShuffle
         self.mode = mode_with_gpu
         # avoid errors with limited devices

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -11,7 +11,6 @@ from theano.tensor.var import TensorConstant
 from theano.tensor.subtensor import (
     Subtensor,
     AdvancedSubtensor,
-    AdvancedBooleanSubtensor,
     AdvancedSubtensor1,
 )
 from theano.tensor.elemwise import DimShuffle
@@ -124,31 +123,30 @@ def test__getitem__Subtensor():
     assert op_types[-1] == Subtensor
 
 
-def test__getitem__AdvancedBooleanSubtensor():
-    # Make sure we get `AdvancedBooleanSubtensor`s for basic indexing operations
+def test__getitem__AdvancedSubtensor_bool():
     x = tt.matrix("x")
     i = tt.type.TensorType("bool", (False, False))("i")
 
     z = x[i]
     op_types = [type(node.op) for node in theano.gof.graph.io_toposort([x, i], [z])]
-    assert op_types[-1] == AdvancedBooleanSubtensor
+    assert op_types[-1] == AdvancedSubtensor
 
     i = tt.type.TensorType("bool", (False,))("i")
     z = x[:, i]
     op_types = [type(node.op) for node in theano.gof.graph.io_toposort([x, i], [z])]
-    assert op_types[-1] == AdvancedBooleanSubtensor
+    assert op_types[-1] == AdvancedSubtensor
 
     i = tt.type.TensorType("bool", (False,))("i")
     z = x[..., i]
     op_types = [type(node.op) for node in theano.gof.graph.io_toposort([x, i], [z])]
-    assert op_types[-1] == AdvancedBooleanSubtensor
+    assert op_types[-1] == AdvancedSubtensor
 
     with pytest.raises(TypeError):
         z = x[[True, False], i]
 
     z = x[tt.ivector("b"), i]
     op_types = [type(node.op) for node in theano.gof.graph.io_toposort([x, i], [z])]
-    assert op_types[-1] == AdvancedBooleanSubtensor
+    assert op_types[-1] == AdvancedSubtensor
 
 
 def test__getitem__AdvancedSubtensor():

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -130,11 +130,9 @@ from .subtensor import (
     GpuSubtensor,
     GpuAdvancedSubtensor,
     GpuAdvancedSubtensor1,
-    GpuAdvancedBooleanSubtensor,
     GpuAdvancedIncSubtensor,
     GpuAdvancedIncSubtensor1,
     GpuAdvancedIncSubtensor1_dev20,
-    GpuAdvancedBooleanIncSubtensor,
     GpuAllocDiag,
     GpuExtractDiag,
 )
@@ -1292,13 +1290,6 @@ def local_gpua_advanced_subtensor(op, context_name, inputs, outputs):
 
 
 @register_opt("fast_compile")
-@op_lifter([tensor.AdvancedBooleanSubtensor])
-@register_opt2([tensor.AdvancedBooleanSubtensor], "fast_compile")
-def local_gpua_advanced_boolean_subtensor(op, context_name, inputs, outputs):
-    return GpuAdvancedBooleanSubtensor()
-
-
-@register_opt("fast_compile")
 @op_lifter([tensor.AdvancedIncSubtensor1])
 @register_opt2([tensor.AdvancedIncSubtensor1], "fast_compile")
 def local_gpua_advanced_incsubtensor1(op, context_name, inputs, outputs):
@@ -1338,20 +1329,6 @@ def local_gpua_advanced_incsubtensor1(op, context_name, inputs, outputs):
 def local_gpua_advanced_incsubtensor(op, context_name, inputs, outputs):
     if not op.set_instead_of_inc:
         return GpuAdvancedIncSubtensor()
-    else:
-        return False
-
-
-# Do not register this optimization for now, as it slows down the
-# execution by a lot in important cases.
-# @register_opt('fast_compile')
-# @op_lifter([tensor.AdvancedBooleanIncSubtensor])
-# @register_opt2([tensor.AdvancedBooleanIncSubtensor], 'fast_compile')
-def local_gpua_advanced_boolean_incsubtensor(op, context_name, inputs, outputs):
-    # GpuAdvancedIncSubtensor only works with a single boolean mask,
-    # but not with fancy combinations.
-    if not op.set_instead_of_inc and len(inputs) == 3:
-        return GpuAdvancedBooleanIncSubtensor()
     else:
         return False
 

--- a/theano/gpuarray/subtensor.py
+++ b/theano/gpuarray/subtensor.py
@@ -683,29 +683,7 @@ class GpuAdvancedSubtensor(HideC, BaseGpuAdvancedSubtensor, tensor.AdvancedSubte
 
     def make_node(self, x, *inputs):
         ctx_name = infer_context_name(x)
-        # This method relies on AdvancedSubtensor.make_node to
-        # call tensor.subtensor.check_and_reject_bool(inputs),
-        # which raises an IndexError if there are any boolean indices.
         rval = tensor.AdvancedSubtensor.make_node(self, x, *inputs)
-        otype = GpuArrayType(
-            dtype=rval.outputs[0].type.dtype,
-            broadcastable=rval.outputs[0].type.broadcastable,
-            context_name=ctx_name,
-        )
-        x = as_gpuarray_variable(x, ctx_name)
-        return gof.Apply(self, [x] + rval.inputs[1:], [otype()])
-
-
-class GpuAdvancedBooleanSubtensor(
-    HideC, BaseGpuAdvancedSubtensor, tensor.AdvancedBooleanSubtensor
-):
-    """
-    AdvancedBooleanSubtensor on the GPU.
-    """
-
-    def make_node(self, x, *inputs):
-        ctx_name = infer_context_name(x)
-        rval = tensor.AdvancedBooleanSubtensor.make_node(self, x, *inputs)
         otype = GpuArrayType(
             dtype=rval.outputs[0].type.dtype,
             broadcastable=rval.outputs[0].type.broadcastable,
@@ -842,27 +820,6 @@ class GpuAdvancedIncSubtensor(
     def make_node(self, x, y, *inputs):
         ctx_name = infer_context_name(x, y)
         rval = tensor.AdvancedIncSubtensor.make_node(self, x, y, *inputs)
-        otype = GpuArrayType(
-            dtype=rval.outputs[0].type.dtype,
-            broadcastable=rval.outputs[0].type.broadcastable,
-            context_name=ctx_name,
-        )
-        x = as_gpuarray_variable(x, ctx_name)
-        y = as_gpuarray_variable(y, ctx_name)
-        return gof.Apply(self, [x, y] + rval.inputs[2:], [otype()])
-
-
-class GpuAdvancedBooleanIncSubtensor(
-    HideC, BaseGpuAdvancedIncSubtensor, tensor.AdvancedBooleanIncSubtensor
-):
-    """
-    Implement AdvancedBooleanIncSubtensor on the gpu.
-
-    """
-
-    def make_node(self, x, y, *inputs):
-        ctx_name = infer_context_name(x, y)
-        rval = tensor.AdvancedBooleanIncSubtensor.make_node(self, x, y, *inputs)
         otype = GpuArrayType(
             dtype=rval.outputs[0].type.dtype,
             broadcastable=rval.outputs[0].type.broadcastable,

--- a/theano/sandbox/jaxify.py
+++ b/theano/sandbox/jaxify.py
@@ -21,8 +21,8 @@ from theano.tensor.subtensor import (
     AdvancedSubtensor1,
     AdvancedIncSubtensor1,
     # Boolean mask indexing and setting
-    BaseAdvancedSubtensor,
-    BaseAdvancedIncSubtensor,
+    AdvancedSubtensor,
+    AdvancedIncSubtensor,
 )
 from theano.scan_module.scan_op import Scan
 from theano.scan_module.scan_utils import scan_args as ScanArgs
@@ -97,7 +97,7 @@ try:
 except AttributeError:
     pass
 
-subtensor_ops = (Subtensor, AdvancedSubtensor1, BaseAdvancedSubtensor)
+subtensor_ops = (Subtensor, AdvancedSubtensor1, AdvancedSubtensor)
 incsubtensor_ops = (IncSubtensor, AdvancedIncSubtensor1)
 
 
@@ -588,18 +588,18 @@ def jax_funcify_IncSubtensor(op):
 _ = [jax_funcify.register(op, jax_funcify_IncSubtensor) for op in incsubtensor_ops]
 
 
-@jax_funcify.register(BaseAdvancedIncSubtensor)
-def jax_funcify_BaseAdvancedIncSubtensor(op):
+@jax_funcify.register(AdvancedIncSubtensor)
+def jax_funcify_AdvancedIncSubtensor(op):
 
     if getattr(op, "set_instead_of_inc", False):
         jax_fn = jax.ops.index_update
     else:
         jax_fn = jax.ops.index_add
 
-    def baseadvancedincsubtensor(x, y, *ilist, jax_fn=jax_fn):
+    def advancedincsubtensor(x, y, *ilist, jax_fn=jax_fn):
         return jax_fn(x, ilist, y)
 
-    return baseadvancedincsubtensor
+    return advancedincsubtensor
 
 
 @jax_funcify.register(FunctionGraph)


### PR DESCRIPTION
This PR removes the redundant `AdvancedBoolean*Subtensor` classes and merges all functionality into the `Advanced*Subtensor` classes.  In doing so, the `set_subtensor` boolean gradient bug in #105 is also fixed.