### PR TITLE
[WIP] Change coverage to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,33 +149,11 @@ jobs:
           FAST_COMPILE: ${{ matrix.fast-compile }}
           FLOAT32: ${{ matrix.float32 }}
 
-      - uses: actions/upload-artifact@v2
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
         with:
-          name: ${{ steps.unique-id.outputs.id }}
-          path: .coverage
-
-  coverage:
-    name: "Merge and upload coverage"
-    needs: test
-    runs-on: ubuntu-latest
-    if: ${{ needs.test.result == 'success' }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - name: Download all artifacts
-        uses: actions/download-artifact@v2
-      - name: Merge and upload coverage
-        run: |
-          python -m pip install coveralls
-          find . -name \.coverage -exec coverage combine --append {} \;
-          coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          fail_ci_if_error: true
+          name: "py${{ matrix.python-version }}: ${{ matrix.part }}"
 
   combine:
     if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
           if [[ $FAST_COMPILE == "1" ]]; then export THEANO_FLAGS=$THEANO_FLAGS,mode=FAST_COMPILE; fi
           if [[ $FLOAT32 == "1" ]]; then export THEANO_FLAGS=$THEANO_FLAGS,floatX=float32; fi
           export THEANO_FLAGS=$THEANO_FLAGS,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,gcc.cxxflags=-pipe
-          python -m pytest -x -r A --verbose --runslow --cov=theano/ --cov-append --no-cov-on-fail $PART
+          python -m pytest -x -r A --verbose --runslow --cov=theano/ --cov-report=xml --no-cov-on-fail $PART
         env:
           MKL_THREADING_LAYER: GNU
           MKL_NUM_THREADS: 1

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Theano.suo
 .ropeproject
 core
 .idea
+.mypy_cache/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  require_ci_to_pass: true
+
+comment:
+    behavior: default
+    branches:
+        - "master"
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+
+    patch:
+      default:
+        target: 100%


### PR DESCRIPTION
This PR changes code coverage provider from coveralls to codecov to add a check on the code coverage of _only_ newly added lines of code. 

For this to work, codecov must be given access to the repo. This can be done from this page: https://github.com/organizations/pymc-devs/settings/installations/3153839 it looks like only by @twiecki. Once permissions are set, codecov should comment on this PR and add a check on the PR. Both the checks and the comment can be further personalized, we should probably merge this only once we are all happy with the codecov setting and seen it can report back to this PR

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [relevant logical changes](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes).
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
