### PR TITLE
Remove Variable.fgraph and Variable.clients properties

### DIFF
--- a/doc/extending/cop.txt
+++ b/doc/extending/cop.txt
@@ -177,13 +177,13 @@ There are less methods to define for an Op than for a Type:
     .. method:: c_cleanup_code_struct(node, name)
 
        Allows you to specify code that will be inserted in the struct
-       destructor of the Op.  This is for cleaninp up allocations and
+       destructor of the `Op`.  This is for cleaninp up allocations and
        stuff like this when the thunk is released (when you "free" a
        compiled function using this op).
 
-    .. method:: infer_shape(node, (i0_shapes,i1_shapes,...))
+    .. method:: infer_shape(fgraph, node, (i0_shapes,i1_shapes,...))
 
-       Allow optimizations to lift the Shape op over this op.  An
+       Allow optimizations to lift the `Shape` `Op` over this `Op`.  An
        example of why this is good is when we only need the shape of a
        variable: we will be able to obtain it without computing the
        variable itself.
@@ -192,8 +192,8 @@ There are less methods to define for an Op than for a Type:
        the shape of one output.
 
        For example, for the matrix-matrix product ``infer_shape`` will
-       have as inputs (node, ((x0,x1), (y0,y1))) and should return
-       [(x0, y1)]. Both the inputs and the return value may be Theano
+       have as inputs ``(fgraph, node, ((x0,x1), (y0,y1)))`` and should return
+       ``[(x0, y1)]``. Both the inputs and the return value may be Theano
        variables.
 
     .. method:: c_code_cache_version()

--- a/doc/extending/extending_theano.txt
+++ b/doc/extending/extending_theano.txt
@@ -114,7 +114,7 @@ possibilities you may encounter or need.  For that refer to
         def R_op(self, inputs, eval_points):
             pass
 
-        def infer_shape(node, input_shapes):
+        def infer_shape(self, fgraph, node, input_shapes):
             pass
 
 An op has to implement some methods defined in the the interface of
@@ -237,9 +237,9 @@ There are other methods that can be optionally defined by the op:
   :attr:`__props__` will also generate a  suitable :func:`__str__` for your op.
   This requires development version after September 1st, 2014 or version 0.7.
 
-  The :func:`infer_shape` method allows to infer the shape of the op
-  output variables, without actually computing the outputs.
-  It takes as input ``node``, a reference to the op Apply node,
+  The :func:`infer_shape` method allows an `Op` to infer the shape of its
+  output variables without actually computing them.
+  It takes as input ``fgraph``, a `FunctionGraph`; ``node``, a reference to the op Apply node;
   and a list of Theano symbolic Varables (``i0_shape``, ``i1_shape``, ...)
   which are the shape of the op input Variables.
   :func:`infer_shape` returns a list where each element is a tuple representing
@@ -302,7 +302,7 @@ Example: Op definition
             z = output_storage[0]
             z[0] = x * 2
 
-        def infer_shape(self, node, i0_shapes):
+        def infer_shape(self, fgraph, node, i0_shapes):
             return i0_shapes
 
         def grad(self, inputs, output_grads):
@@ -333,7 +333,7 @@ Example: Op definition
             z = output_storage[0]
             z[0] = x * 2
 
-        def infer_shape(self, node, i0_shapes):
+        def infer_shape(self, fgraph, node, i0_shapes):
             return i0_shapes
 
         def grad(self, inputs, output_grads):
@@ -508,7 +508,7 @@ and ``b`` are equal.
             z = output_storage[0]
             z[0] = self.a * x + self.b
 
-        def infer_shape(self, node, i0_shapes):
+        def infer_shape(self, fgraph, node, i0_shapes):
             return i0_shapes
 
         def grad(self, inputs, output_grads):
@@ -750,12 +750,13 @@ signature:
 
 .. code-block:: none
 
-    def infer_shape(node, input_shapes):
+    def infer_shape(fgraph, node, input_shapes):
         # ...
         return output_shapes
 
   - `input_shapes` and `output_shapes` are lists of tuples that
-    represent the shape of the corresponding inputs/outputs.
+    represent the shape of the corresponding inputs/outputs, and `fgraph`
+    is a `FunctionGraph`.
 
 .. note::
 
@@ -788,7 +789,7 @@ as_op Example
     from theano import function
     from theano.compile.ops import as_op
 
-    def infer_shape_numpy_dot(node, input_shapes):
+    def infer_shape_numpy_dot(fgraph, node, input_shapes):
         ashp, bshp = input_shapes
         return [ashp[:-1] + bshp[-1:]]
 

--- a/doc/extending/extending_theano_solution_1.py
+++ b/doc/extending/extending_theano_solution_1.py
@@ -34,7 +34,7 @@ class ProdOp(theano.Op):
         z = output_storage[0]
         z[0] = x * y
 
-    def infer_shape(self, node, i0_shapes):
+    def infer_shape(self, fgraph, node, i0_shapes):
         return [i0_shapes[0]]
 
     def grad(self, inputs, output_grads):
@@ -71,7 +71,7 @@ class SumDiffOp(theano.Op):
         z1[0] = x + y
         z2[0] = x - y
 
-    def infer_shape(self, node, i0_shapes):
+    def infer_shape(self, fgraph, node, i0_shapes):
         return [i0_shapes[0], i0_shapes[0]]
 
     def grad(self, inputs, output_grads):
@@ -172,7 +172,7 @@ import numpy as np
 from theano.compile.ops import as_op
 
 
-def infer_shape_numpy_dot(node, input_shapes):
+def infer_shape_numpy_dot(fgraph, node, input_shapes):
     ashp, bshp = input_shapes
     return [ashp[:-1] + bshp[-1:]]
 
@@ -183,7 +183,7 @@ def numpy_add(a, b):
     return np.add(a, b)
 
 
-def infer_shape_numpy_add_sub(node, input_shapes):
+def infer_shape_numpy_add_sub(fgraph, node, input_shapes):
     ashp, bshp = input_shapes
     # Both inputs should have that same shape, so we just return one of them.
     return [ashp[0]]

--- a/doc/extending/fibby.txt
+++ b/doc/extending/fibby.txt
@@ -110,7 +110,7 @@ TODO: talk about OPTIMIZATION STAGES
    # Remove any fibby(zeros(...))
    @theano.tensor.opt.register_specialize
    @theano.gof.local_optimizer([fibby])
-   def fibby_of_zero(node):
+   def fibby_of_zero(fgraph, node):
        if node.op == fibby:
            x = node.inputs[0]
            try:
@@ -124,8 +124,8 @@ tells Theano to use it in the specialization stage.
 The ``local_optimizer`` decorator builds a class instance around our global
 function.  The ``[fibby]`` argument is a hint that our optimizer works on nodes
 whose ``.op`` attribute equals ``fibby``.
-The function here (``fibby_of_zero``) expects an ``Apply`` instance as an
-argument for parameter ``node``. It tests using
+The function here (``fibby_of_zero``) expects a ``FunctionGraph`` and an ``Apply`` instance as
+arguments for the parameters ``fgraph`` and ``node``. It tests using
 function ``get_scalar_constant_value``, which determines if a
 Variable (``x``) is guaranteed to be a constant, and if so, what constant.
 

--- a/doc/extending/graphstructures.txt
+++ b/doc/extending/graphstructures.txt
@@ -344,7 +344,7 @@ pairs:
   function outputs this variable.
 
 In both types of pairs, the second element of the tuple is an index,
-such that: ``var.clients[*][0].inputs[index]`` or
+such that: ``fgraph.clients[var][*][0].inputs[index]`` or
 ``fgraph.outputs[index]`` is that variable.
 
 
@@ -357,15 +357,16 @@ Sum{acc_dtype=float64} [id A] ''   1
    |TensorConstant{(1,) of 1.0} [id C]
    |<TensorType(float64, vector)> [id D]
 >>> # Sorted list of all nodes in the compiled graph.
->>> topo = f.maker.fgraph.toposort()
->>> topo[0].outputs[0].clients
+>>> fgraph = f.maker.fgraph
+>>> topo = fgraph.toposort()
+>>> fgraph.clients[topo[0].outputs[0]]
 [(Sum{acc_dtype=float64}(Elemwise{add,no_inplace}.0), 0)]
->>> topo[1].outputs[0].clients
+>>> fgraph.clients[topo[1].outputs[0]]
 [('output', 0)]
 
 >>> # An internal variable
 >>> var = topo[0].outputs[0]
->>> client = var.clients[0]
+>>> client = fgraph.clients[var][0]
 >>> client
 (Sum{acc_dtype=float64}(Elemwise{add,no_inplace}.0), 0)
 >>> type(client[0])
@@ -374,10 +375,10 @@ Sum{acc_dtype=float64} [id A] ''   1
 
 >>> # An output of the graph
 >>> var = topo[1].outputs[0]
->>> client = var.clients[0]
+>>> client = fgraph.clients[var][0]
 >>> client
 ('output', 0)
->>> assert f.maker.fgraph.outputs[client[1]] is var
+>>> assert fgraph.outputs[client[1]] is var
 
 
 Automatic Differentiation

--- a/doc/extending/op.txt
+++ b/doc/extending/op.txt
@@ -254,7 +254,7 @@ Optional methods or attributes
      If you set `__props__`, this will be automatically generated.
      You can still overide it for custom output.
 
-.. function:: do_constant_folding(node)
+.. function:: do_constant_folding(fgraph, node)
 
    *Default:* Return True
 
@@ -323,7 +323,7 @@ These are the function required to work with gradient.grad().
   return the gradient of the Op's output. theano.tensor.grad computes
   gradients; Op.grad is a helper function that computes terms that
   appear in gradients.
-  
+
   If an Op has a single vector-valued output y and a single
   vector-valued input x, then the grad method will be passed x and a
   second vector z. Define J to be the Jacobian of y with respect to
@@ -393,7 +393,7 @@ These are the function required to work with gradient.grad().
   :math:`[grad_{x_1}(C), grad_{x_2}(C), ..., grad_{x_m}(C)]`, where
   :math:`(grad_{y}(Z))_i = \frac{\partial Z}{\partial y_i}` (and
   :math:`i` can stand for multiple dimensions).
- 
+
   In other words, :func:`grad` does not return :math:`\frac{d f_i}{d
   x_j}`, but instead the appropriate dot product specified by the
   chain rule: :math:`\frac{d C}{d x_j} = \frac{d C}{d f_i} \cdot
@@ -402,7 +402,7 @@ These are the function required to work with gradient.grad().
 
   Theano currently imposes the following constraints on the values
   returned by the grad method:
-  
+
   1) They must be Variable instances.
   2) When they are types that have dtypes, they must never have an integer dtype.
 
@@ -525,27 +525,27 @@ These are the function required to work with gradient.grad().
 
    This function implements the application of the R-operator on the
    function represented by your op. Let assume that function is :math:`f`,
-   with input :math:`x`, applying the R-operator means computing the 
-   Jacobian of :math:`f` and right-multiplying it by :math:`v`, the evaluation 
-   point, namely: :math:`\frac{\partial f}{\partial x} v`. 
+   with input :math:`x`, applying the R-operator means computing the
+   Jacobian of :math:`f` and right-multiplying it by :math:`v`, the evaluation
+   point, namely: :math:`\frac{\partial f}{\partial x} v`.
 
-   ``inputs`` are the symbolic variables corresponding to the value of 
+   ``inputs`` are the symbolic variables corresponding to the value of
    the input where you want to evaluate the jacobian, and ``eval_points``
    are the symbolic variables corresponding to the value you want to
-   right multiply the jacobian with. 
+   right multiply the jacobian with.
 
    Same conventions as for the grad method hold. If your op is not
-   differentiable, you can return None. Note that in contrast to 
+   differentiable, you can return None. Note that in contrast to
    the method :func:`grad`, for :func:`R_op` you need to return the
    same number of outputs as there are ouputs of the op. You can think
    of it in the following terms. You have all your inputs concatenated
-   into a single vector :math:`x`. You do the same with the evaluation 
+   into a single vector :math:`x`. You do the same with the evaluation
    points (which are as many as inputs and of the shame shape) and obtain
-   another vector :math:`v`. For each output, you reshape it into a vector, 
-   compute the jacobian of that vector with respect to :math:`x` and 
+   another vector :math:`v`. For each output, you reshape it into a vector,
+   compute the jacobian of that vector with respect to :math:`x` and
    multiply it by :math:`v`. As a last step you reshape each of these
-   vectors you obtained for each outputs (that have the same shape as 
-   the outputs) back to their corresponding shapes and return them as the 
+   vectors you obtained for each outputs (that have the same shape as
+   the outputs) back to their corresponding shapes and return them as the
    output of the :func:`R_op` method.
 
    :ref:`List of op with r op support <R_op_list>`.
@@ -777,4 +777,3 @@ your disposal to create these objects as efficiently as possible.
 
 **Exercise**: Make a generic DoubleOp, where the number of
 arguments can also be given as a parameter.
-

--- a/doc/extending/op.txt
+++ b/doc/extending/op.txt
@@ -215,7 +215,7 @@ Optional methods or attributes
    will use your Op and build the graphs that you want and call that
    instead of the Op instance directly.
 
-.. function:: infer_shape(node, shapes)
+.. function:: infer_shape(fgraph, node, shapes)
 
    This function is needed for shape optimization. ``shapes`` is a
    list with one tuple for each input of the Apply node (which corresponds

--- a/doc/extending/optimization.txt
+++ b/doc/extending/optimization.txt
@@ -89,14 +89,14 @@ A local optimization is an object which defines the following methods:
 
 .. class:: LocalOptimizer
 
-    .. method:: transform(node)
+    .. method:: transform(fgraph, node)
 
-      This method takes an :ref:`apply` node and returns either ``False`` to
-      signify that no changes are to be done or a list of Variables which
-      matches the length of the node's ``outputs`` list. When the
-      LocalOptimizer is applied by a Navigator, the outputs of the node
-      passed as argument to the LocalOptimizer will be replaced by the
-      list returned.
+      This method takes a :ref:`FunctionGraph` and an :ref:`Apply` node and
+      returns either ``False`` to signify that no changes are to be done or a
+      list of `Variable`s which matches the length of the node's ``outputs``
+      list. When the `LocalOptimizer` is applied by a `Navigator`, the outputs
+      of the node passed as argument to the `LocalOptimizer` will be replaced by
+      the list returned.
 
 
 
@@ -252,7 +252,7 @@ The local version of the above code would be the following:
 .. testcode::
 
    class LocalSimplify(gof.LocalOptimizer):
-       def transform(self, node):
+       def transform(self, fgraph, node):
            if node.op == true_div:
                x, y = node.inputs
                if x.owner and x.owner.op == mul:

--- a/doc/extending/optimization.txt
+++ b/doc/extending/optimization.txt
@@ -57,7 +57,7 @@ Global optimization
 A global optimization (or optimizer) is an object which defines the following
 methods:
 
-.. class:: Optimizer
+.. class:: GlobalOptimizer
 
     .. method:: apply(fgraph)
 
@@ -75,7 +75,7 @@ methods:
 
       This is the interface function called by Theano.
 
-      *Default:* this is defined by Optimizer as ``add_requirement(fgraph);
+      *Default:* this is defined by GlobalOptimizer as ``add_requirement(fgraph);
       apply(fgraph)``.
 
 See the section about :class:`FunctionGraph` to understand how to define these
@@ -125,7 +125,7 @@ simplification described above:
    from theano import gof
    from theano.gof import toolbox
 
-   class Simplify(gof.Optimizer):
+   class Simplify(gof.GlobalOptimizer):
        def add_requirements(self, fgraph):
            fgraph.attach_feature(toolbox.ReplaceValidate())
        def apply(self, fgraph):
@@ -471,7 +471,7 @@ Here are a few examples of how to use a Query on optdb to produce an
 Optimizer:
 
 .. testcode::
-   
+
    from theano.gof import Query
    from theano.compile import optdb
 

--- a/doc/hpcs2011_tutorial/presentation.tex
+++ b/doc/hpcs2011_tutorial/presentation.tex
@@ -1390,7 +1390,7 @@ class MyOp(Op):
 {\color{gray}# optional:}
     def __init__(self, ...):
     def grad(self, inputs, g):
-    def infer_shape(node, (i0_shapes, ...))
+    def infer_shape(fgraph, node, (i0_shapes, ...))
 \end{Verbatim}
 \end{frame}
 

--- a/doc/tutorial/debug_faq.txt
+++ b/doc/tutorial/debug_faq.txt
@@ -363,11 +363,11 @@ shows how to print all inputs and outputs:
     from __future__ import print_function
     import theano
 
-    def inspect_inputs(i, node, fn):
+    def inspect_inputs(fgraph, i, node, fn):
         print(i, node, "input(s) value(s):", [input[0] for input in fn.inputs],
               end='')
 
-    def inspect_outputs(i, node, fn):
+    def inspect_outputs(fgraph, i, node, fn):
         print(" output(s) value(s):", [output[0] for output in fn.outputs])
 
     x = theano.tensor.dscalar('x')
@@ -406,7 +406,7 @@ can be achieved as follows:
     # ``theano.compile.monitormode.detect_nan`` that will always
     # contain the current suggested version.
 
-    def detect_nan(i, node, fn):
+    def detect_nan(fgraph, i, node, fn):
         for output in fn.outputs:
             if (not isinstance(output[0], numpy.random.RandomState) and
                 numpy.isnan(output[0]).any()):

--- a/tests/compile/test_debugmode.py
+++ b/tests/compile/test_debugmode.py
@@ -219,7 +219,7 @@ def test_badthunkoutput():
 
 def test_badoptimization():
     @gof.local_optimizer([theano.tensor.add])
-    def insert_broken_add(node):
+    def insert_broken_add(fgraph, node):
         if node.op == theano.tensor.add:
             return [off_by_half(*node.inputs)]
         return False
@@ -245,7 +245,7 @@ def test_badoptimization_opt_err():
     # This variant of test_badoptimization() replace the working code
     # with a new apply node that will raise an error.
     @gof.local_optimizer([theano.tensor.add])
-    def insert_bigger_b_add(node):
+    def insert_bigger_b_add(fgraph, node):
         if node.op == theano.tensor.add:
             inputs = list(node.inputs)
             if inputs[-1].owner is None:
@@ -254,7 +254,7 @@ def test_badoptimization_opt_err():
         return False
 
     @gof.local_optimizer([theano.tensor.add])
-    def insert_bad_dtype(node):
+    def insert_bad_dtype(fgraph, node):
         if node.op == theano.tensor.add:
             inputs = list(node.inputs)
             if inputs[-1].owner is None:
@@ -310,7 +310,7 @@ def test_stochasticoptimization():
     last_time_replaced = [False]
 
     @gof.local_optimizer([theano.tensor.add])
-    def insert_broken_add_sometimes(node):
+    def insert_broken_add_sometimes(fgraph, node):
         if node.op == theano.tensor.add:
             last_time_replaced[0] = not last_time_replaced[0]
             if last_time_replaced[0]:

--- a/tests/compile/test_monitormode.py
+++ b/tests/compile/test_monitormode.py
@@ -11,7 +11,7 @@ def test_detect_nan():
 
     nan_detected = [False]
 
-    def detect_nan(i, node, fn):
+    def detect_nan(fgraph, i, node, fn):
         for output in fn.outputs:
             if np.isnan(output[0]).any():
                 print("*** NaN detected ***")
@@ -41,7 +41,7 @@ def test_optimizer():
 
     nan_detected = [False]
 
-    def detect_nan(i, node, fn):
+    def detect_nan(fgraph, i, node, fn):
         for output in fn.outputs:
             if np.isnan(output[0]).any():
                 print("*** NaN detected ***")
@@ -73,7 +73,7 @@ def test_not_inplace():
 
     nan_detected = [False]
 
-    def detect_nan(i, node, fn):
+    def detect_nan(fgraph, i, node, fn):
         for output in fn.outputs:
             if np.isnan(output[0]).any():
                 print("*** NaN detected ***")

--- a/tests/compile/test_ops.py
+++ b/tests/compile/test_ops.py
@@ -69,7 +69,7 @@ class TestOpDecorator(utt.InferShapeTester):
         y = dvector("y")
         y.tag.test_value = [0, 0, 0, 0]
 
-        def infer_shape(node, shapes):
+        def infer_shape(fgraph, node, shapes):
             x, y = shapes
             return [y]
 

--- a/tests/gof/test_destroyhandler.py
+++ b/tests/gof/test_destroyhandler.py
@@ -144,12 +144,12 @@ def test_misc():
     g = Env([x, y, z], [e])
     assert g.consistent()
     PatternOptimizer((transpose_view, (transpose_view, "x")), "x").optimize(g)
-    assert str(g) == "[x]"
+    assert str(g) == "FunctionGraph(x)"
     new_e = add(x, y)
     g.replace_validate(x, new_e)
-    assert str(g) == "[Add(x, y)]"
+    assert str(g) == "FunctionGraph(Add(x, y))"
     g.replace(new_e, dot(add_in_place(x, y), transpose_view(x)))
-    assert str(g) == "[Dot(AddInPlace(x, y), TransposeView(x))]"
+    assert str(g) == "FunctionGraph(Dot(AddInPlace(x, y), TransposeView(x)))"
     assert not g.consistent()
 
 
@@ -325,7 +325,10 @@ def test_long_destroyers_loop():
     OpSubOptimizer(add, add_in_place).optimize(g)
     assert g.consistent()
     # we don't want to see that!
-    assert str(g) != "[Dot(Dot(AddInPlace(x, y), AddInPlace(y, z)), AddInPlace(z, x))]"
+    assert (
+        str(g)
+        != "FunctionGraph(Dot(Dot(AddInPlace(x, y), AddInPlace(y, z)), AddInPlace(z, x)))"
+    )
     e2 = dot(dot(add_in_place(x, y), add_in_place(y, z)), add_in_place(z, x))
     with pytest.raises(InconsistencyError):
         Env(*graph.clone([x, y, z], [e2]))

--- a/tests/gof/test_fg.py
+++ b/tests/gof/test_fg.py
@@ -216,13 +216,6 @@ class TestFunctionGraph:
         var5 = op3(var4, var2, var2)
         fg = FunctionGraph([var1, var2], [var3, var5], clone=False)
 
-        with pytest.raises(Exception, match="Cannot replace.*"):
-            var4.fgraph = object()
-            # Trigger a `FunctionGraph` ownership error
-            fg.replace(var4, var1, verbose=True)
-
-        var4.fgraph = fg
-
         with pytest.raises(BadOptimization):
             var0 = MyVariable2("var0")
             # The types don't match and one cannot be converted to the other
@@ -262,7 +255,6 @@ class TestFunctionGraph:
 
         with pytest.raises(MissingInputError):
             var0 = MyVariable("var0")
-            var0.fgraph = object()
 
             # FIXME TODO XXX: This breaks the state of the `FunctionGraph`,
             # because it doesn't check for validity of the replacement *first*.
@@ -299,7 +291,6 @@ class TestFunctionGraph:
 
         with pytest.raises(Exception, match="Undeclared input.*"):
             var6 = MyVariable2("var6")
-            var6.fgraph = fg
             fg.clients[var6] = [(var5.owner, 3)]
             fg.variables.add(var6)
             var5.owner.inputs.append(var6)

--- a/tests/gof/test_fg.py
+++ b/tests/gof/test_fg.py
@@ -329,3 +329,18 @@ class TestFunctionGraph:
             fg.add_client(var4, (var3.owner, 0))
 
             fg.check_integrity()
+
+    def test_contains(self):
+
+        var1 = MyVariable("var1")
+        var2 = MyVariable("var2")
+        var3 = op1(var2, var1)
+        var4 = op2(var3, var2)
+        var5 = op3(var4, var2, var2)
+        fg = FunctionGraph([var1, var2], [var3, var5], clone=False)
+
+        assert var1 in fg
+        assert var3 in fg
+        assert var3.owner in fg
+        assert var5 in fg
+        assert var5.owner in fg

--- a/tests/gof/test_fg.py
+++ b/tests/gof/test_fg.py
@@ -54,10 +54,10 @@ class TestFunctionGraph:
         assert fg.update_mapping is None
         assert fg.check_integrity() is None
         assert fg.variables == {var1, var2, var3, var4}
-        assert fg.clients(var1) == [(var3.owner, 0)]
-        assert fg.clients(var2) == [(var4.owner, 1)]
-        assert fg.clients(var3) == [(var4.owner, 0), ("output", 0)]
-        assert fg.clients(var4) == [("output", 1)]
+        assert fg.get_clients(var1) == [(var3.owner, 0)]
+        assert fg.get_clients(var2) == [(var4.owner, 1)]
+        assert fg.get_clients(var3) == [(var4.owner, 0), ("output", 0)]
+        assert fg.get_clients(var4) == [("output", 1)]
 
     def test_remove_client(self):
         var1 = MyVariable("var1")
@@ -68,7 +68,7 @@ class TestFunctionGraph:
         fg = FunctionGraph([var1, var2], [var3, var5], clone=False)
 
         assert fg.variables == {var1, var2, var3, var4, var5}
-        assert fg.clients(var2) == [
+        assert fg.get_clients(var2) == [
             (var3.owner, 0),
             (var4.owner, 1),
             (var5.owner, 1),
@@ -77,7 +77,7 @@ class TestFunctionGraph:
 
         fg.remove_client(var2, (var4.owner, 1))
 
-        assert fg.clients(var2) == [
+        assert fg.get_clients(var2) == [
             (var3.owner, 0),
             (var5.owner, 1),
             (var5.owner, 2),
@@ -85,7 +85,7 @@ class TestFunctionGraph:
 
         fg.remove_client(var1, (var3.owner, 1))
 
-        assert fg.clients(var1) == []
+        assert fg.get_clients(var1) == []
 
         assert var4.owner in fg.apply_nodes
 
@@ -125,7 +125,7 @@ class TestFunctionGraph:
         assert hasattr(var6.owner.tag, "imported_by")
         assert var6 in fg.variables
         assert var6.owner in fg.apply_nodes
-        assert (var6.owner, 0) in var2.clients
+        assert (var6.owner, 0) in fg.get_clients(var2)
 
     def test_import_var(self):
 
@@ -171,20 +171,20 @@ class TestFunctionGraph:
 
         old_apply_nodes = set(fg.apply_nodes)
         old_variables = set(fg.variables)
-        old_var5_clients = list(var5.clients)
+        old_var5_clients = list(fg.get_clients(var5))
 
         # We're replacing with the same variable, so nothing should happen
         fg.change_input(var5.owner, 1, var2)
 
         assert old_apply_nodes == fg.apply_nodes
         assert old_variables == fg.variables
-        assert old_var5_clients == var5.clients
+        assert old_var5_clients == fg.get_clients(var5)
 
         # Perform a valid `Apply` node input change
         fg.change_input(var5.owner, 1, var1)
 
         assert var5.owner.inputs[1] is var1
-        assert (var5.owner, 1) not in var2.clients
+        assert (var5.owner, 1) not in fg.get_clients(var2)
 
     @change_flags(compute_test_value="raise")
     def test_replace_test_value(self):
@@ -284,11 +284,11 @@ class TestFunctionGraph:
 
         with pytest.raises(Exception, match="Inconsistent clients.*"):
             fg.apply_nodes.add(var5.owner)
-            var2.clients.remove((var5.owner, 1))
+            fg.remove_client(var2, (var5.owner, 1))
 
             fg.check_integrity()
 
-        var2.clients.append((var5.owner, 1))
+        fg.add_client(var2, (var5.owner, 1))
 
         with pytest.raises(Exception, match="The variables are.*"):
             fg.variables.remove(var4)
@@ -300,7 +300,7 @@ class TestFunctionGraph:
         with pytest.raises(Exception, match="Undeclared input.*"):
             var6 = MyVariable2("var6")
             var6.fgraph = fg
-            var6.clients = [(var5.owner, 3)]
+            fg.clients[var6] = [(var5.owner, 3)]
             fg.variables.add(var6)
             var5.owner.inputs.append(var6)
 
@@ -312,20 +312,20 @@ class TestFunctionGraph:
         # TODO: What if the index value is greater than 1?  It will throw an
         # `IndexError`, but that doesn't sound like anything we'd want.
         with pytest.raises(Exception, match="Inconsistent clients list.*"):
-            var4.clients.append(("output", 1))
+            fg.add_client(var4, ("output", 1))
 
             fg.check_integrity()
 
-        var4.clients.remove(("output", 1))
+        fg.remove_client(var4, ("output", 1))
 
         with pytest.raises(Exception, match="Client not in FunctionGraph.*"):
-            var4.clients.append((var6.owner, 0))
+            fg.add_client(var4, (var6.owner, 0))
 
             fg.check_integrity()
 
-        var4.clients.remove((var6.owner, 0))
+        fg.remove_client(var4, (var6.owner, 0))
 
         with pytest.raises(Exception, match="Inconsistent clients list.*"):
-            var4.clients.append((var3.owner, 0))
+            fg.add_client(var4, (var3.owner, 0))
 
             fg.check_integrity()

--- a/tests/gof/test_link.py
+++ b/tests/gof/test_link.py
@@ -138,7 +138,7 @@ class TestWrapLinker:
     def test_0(self):
         nodes = []
 
-        def wrap(i, node, th):
+        def wrap(fgraph, i, node, th):
             nodes.append(node.op)
 
         x, y, z = inputs()
@@ -155,7 +155,7 @@ class TestWrapLinker:
     def test_1(self):
         nodes = []
 
-        def wrap(i, node, th):
+        def wrap(fgraph, i, node, th):
             nodes.append(node.op)
             th()
 

--- a/tests/gof/test_op.py
+++ b/tests/gof/test_op.py
@@ -79,7 +79,7 @@ class NoInputOp(Op):
 class StructOp(Op):
     __props__ = ()
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         # we are not constant
         return False
 

--- a/tests/gof/test_opt.py
+++ b/tests/gof/test_opt.py
@@ -549,7 +549,8 @@ def test_pre_constant_merge_slice():
     adv = AdvancedSubtensor()(tt.matrix(), [2, 3], const_slice)
     pre_constant_merge(adv)
 
-    cst = pre_greedy_local_optimizer([constant_folding], ms)
+    fgraph = FunctionGraph([], [])
+    cst = pre_greedy_local_optimizer(fgraph, [constant_folding], ms)
     assert isinstance(cst, SliceConstant)
 
     # Make sure constant of slice signature is hashable.

--- a/tests/gof/test_opt.py
+++ b/tests/gof/test_opt.py
@@ -43,7 +43,7 @@ class TestPatternOptimizer:
         e = op1(op2(x, y), z)
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op1, (op2, "1", "2"), "3"), (op4, "3", "2")).optimize(g)
-        assert str(g) == "[Op4(z, y)]"
+        assert str(g) == "FunctionGraph(Op4(z, y))"
 
     def test_nested_out_pattern(self):
         x, y, z = inputs()
@@ -52,7 +52,7 @@ class TestPatternOptimizer:
         PatternOptimizer(
             (op1, "1", "2"), (op4, (op1, "1"), (op2, "2"), (op3, "1", "2"))
         ).optimize(g)
-        assert str(g) == "[Op4(Op1(x), Op2(y), Op3(x, y))]"
+        assert str(g) == "FunctionGraph(Op4(Op1(x), Op2(y), Op3(x, y)))"
 
     def test_unification_1(self):
         x, y, z = inputs()
@@ -63,7 +63,7 @@ class TestPatternOptimizer:
             (op4, "2", "1"),
         ).optimize(g)
         # So the replacement should occur
-        assert str(g) == "[Op4(z, x)]"
+        assert str(g) == "FunctionGraph(Op4(z, x))"
 
     def test_unification_2(self):
         x, y, z = inputs()
@@ -74,7 +74,7 @@ class TestPatternOptimizer:
             (op4, "2", "1"),
         ).optimize(g)
         # The replacement should NOT occur
-        assert str(g) == "[Op1(Op2(x, y), z)]"
+        assert str(g) == "FunctionGraph(Op1(Op2(x, y), z))"
 
     def test_replace_subgraph(self):
         # replacing inside the graph
@@ -82,7 +82,7 @@ class TestPatternOptimizer:
         e = op1(op2(x, y), z)
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op2, "1", "2"), (op1, "2", "1")).optimize(g)
-        assert str(g) == "[Op1(Op1(y, x), z)]"
+        assert str(g) == "FunctionGraph(Op1(Op1(y, x), z))"
 
     def test_no_recurse(self):
         # if the out pattern is an acceptable in pattern
@@ -92,7 +92,7 @@ class TestPatternOptimizer:
         e = op1(op2(x, y), z)
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op2, "1", "2"), (op2, "2", "1"), ign=True).optimize(g)
-        assert str(g) == "[Op1(Op2(y, x), z)]"
+        assert str(g) == "FunctionGraph(Op1(Op2(y, x), z))"
 
     def test_multiple(self):
         # it should replace all occurrences of the pattern
@@ -100,7 +100,7 @@ class TestPatternOptimizer:
         e = op1(op2(x, y), op2(x, y), op2(y, z))
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op2, "1", "2"), (op4, "1")).optimize(g)
-        assert str(g) == "[Op1(Op4(x), Op4(x), Op4(y))]"
+        assert str(g) == "FunctionGraph(Op1(Op4(x), Op4(x), Op4(y)))"
 
     def test_nested_even(self):
         # regardless of the order in which we optimize, this
@@ -109,21 +109,21 @@ class TestPatternOptimizer:
         e = op1(op1(op1(op1(x))))
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op1, (op1, "1")), "1").optimize(g)
-        assert str(g) == "[x]"
+        assert str(g) == "FunctionGraph(x)"
 
     def test_nested_odd(self):
         x, y, z = inputs()
         e = op1(op1(op1(op1(op1(x)))))
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op1, (op1, "1")), "1").optimize(g)
-        assert str(g) == "[Op1(x)]"
+        assert str(g) == "FunctionGraph(Op1(x))"
 
     def test_expand(self):
         x, y, z = inputs()
         e = op1(op1(op1(x)))
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op1, "1"), (op2, (op1, "1")), ign=True).optimize(g)
-        assert str(g) == "[Op2(Op1(Op2(Op1(Op2(Op1(x))))))]"
+        assert str(g) == "FunctionGraph(Op2(Op1(Op2(Op1(Op2(Op1(x)))))))"
 
     def test_ambiguous(self):
         # this test should always work with TopoOptimizer and the
@@ -133,7 +133,7 @@ class TestPatternOptimizer:
         e = op1(op1(op1(op1(op1(x)))))
         g = FunctionGraph([x, y, z], [e])
         TopoPatternOptimizer((op1, (op1, "1")), (op1, "1"), ign=False).optimize(g)
-        assert str(g) == "[Op1(x)]"
+        assert str(g) == "FunctionGraph(Op1(x))"
 
     def test_constant_unification(self):
         x = Constant(MyType(), 2, name="x")
@@ -142,7 +142,7 @@ class TestPatternOptimizer:
         e = op1(op1(x, y), y)
         g = FunctionGraph([y], [e])
         PatternOptimizer((op1, z, "1"), (op2, "1", z)).optimize(g)
-        assert str(g) == "[Op1(Op2(y, z), y)]"
+        assert str(g) == "FunctionGraph(Op1(Op2(y, z), y))"
 
     def test_constraints(self):
         x, y, z = inputs()
@@ -156,14 +156,14 @@ class TestPatternOptimizer:
         PatternOptimizer(
             (op1, {"pattern": "1", "constraint": constraint}), (op3, "1")
         ).optimize(g)
-        assert str(g) == "[Op4(Op3(Op2(x, y)), Op1(Op1(x, y)))]"
+        assert str(g) == "FunctionGraph(Op4(Op3(Op2(x, y)), Op1(Op1(x, y))))"
 
     def test_match_same(self):
         x, y, z = inputs()
         e = op1(x, x)
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op1, "x", "y"), (op3, "x", "y")).optimize(g)
-        assert str(g) == "[Op3(x, x)]"
+        assert str(g) == "FunctionGraph(Op3(x, x))"
 
     def test_match_same_illegal(self):
         x, y, z = inputs()
@@ -177,7 +177,7 @@ class TestPatternOptimizer:
         PatternOptimizer(
             {"pattern": (op1, "x", "y"), "constraint": constraint}, (op3, "x", "y")
         ).optimize(g)
-        assert str(g) == "[Op2(Op1(x, x), Op3(x, y))]"
+        assert str(g) == "FunctionGraph(Op2(Op1(x, x), Op3(x, y)))"
 
     def test_multi(self):
         x, y, z = inputs()
@@ -185,7 +185,7 @@ class TestPatternOptimizer:
         e = op3(op4(e0), e0)
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op4, (op1, "x", "y")), (op3, "x", "y")).optimize(g)
-        assert str(g) == "[Op3(Op4(*1 -> Op1(x, y)), *1)]"
+        assert str(g) == "FunctionGraph(Op3(Op4(*1 -> Op1(x, y)), *1))"
 
     def test_eq(self):
         # replacing the whole graph
@@ -194,7 +194,7 @@ class TestPatternOptimizer:
         g = FunctionGraph([x, y, z], [e])
         PatternOptimizer((op1, (op_z, "1", "2"), "3"), (op4, "3", "2")).optimize(g)
         str_g = str(g)
-        assert str_g == "[Op4(z, y)]"
+        assert str_g == "FunctionGraph(Op4(z, y))"
 
 
 #     def test_multi_ingraph(self):
@@ -205,7 +205,7 @@ class TestPatternOptimizer:
 #         g = FunctionGraph([x, y, z], [e])
 #         PatternOptimizer((op4, (op1, 'x', 'y'), (op1, 'x', 'y')),
 #                          (op3, 'x', 'y')).optimize(g)
-#         assert str(g) == "[Op3(x, y)]"
+#         assert str(g) == "FunctionGraph(Op3(x, y))"
 
 
 def OpSubOptimizer(op1, op2):
@@ -218,14 +218,14 @@ class TestOpSubOptimizer:
         e = op1(op1(op1(op1(op1(x)))))
         g = FunctionGraph([x, y, z], [e])
         OpSubOptimizer(op1, op2).optimize(g)
-        assert str(g) == "[Op2(Op2(Op2(Op2(Op2(x)))))]"
+        assert str(g) == "FunctionGraph(Op2(Op2(Op2(Op2(Op2(x))))))"
 
     def test_straightforward_2(self):
         x, y, z = inputs()
         e = op1(op2(x), op3(y), op4(z))
         g = FunctionGraph([x, y, z], [e])
         OpSubOptimizer(op3, op4).optimize(g)
-        assert str(g) == "[Op1(Op2(x), Op4(y), Op4(z))]"
+        assert str(g) == "FunctionGraph(Op1(Op2(x), Op4(y), Op4(z)))"
 
 
 class NoInputOp(Op):
@@ -247,7 +247,7 @@ class TestMergeOptimizer:
         e = op1(op2(x, y), op2(x, y), op2(x, z))
         g = FunctionGraph([x, y, z], [e])
         MergeOptimizer().optimize(g)
-        assert str(g) == "[Op1(*1 -> Op2(x, y), *1, Op2(x, z))]"
+        assert str(g) == "FunctionGraph(Op1(*1 -> Op2(x, y), *1, Op2(x, z)))"
 
     def test_constant_merging(self):
         x = MyVariable("x")
@@ -258,8 +258,8 @@ class TestMergeOptimizer:
         MergeOptimizer().optimize(g)
         strg = str(g)
         assert (
-            strg == "[Op1(*1 -> Op2(x, y), *1, *1)]"
-            or strg == "[Op1(*1 -> Op2(x, z), *1, *1)]"
+            strg == "FunctionGraph(Op1(*1 -> Op2(x, y), *1, *1))"
+            or strg == "FunctionGraph(Op1(*1 -> Op2(x, z), *1, *1))"
         )
 
     def test_deep_merge(self):
@@ -267,14 +267,14 @@ class TestMergeOptimizer:
         e = op1(op3(op2(x, y), z), op4(op3(op2(x, y), z)))
         g = FunctionGraph([x, y, z], [e])
         MergeOptimizer().optimize(g)
-        assert str(g) == "[Op1(*1 -> Op3(Op2(x, y), z), Op4(*1))]"
+        assert str(g) == "FunctionGraph(Op1(*1 -> Op3(Op2(x, y), z), Op4(*1)))"
 
     def test_no_merge(self):
         x, y, z = inputs()
         e = op1(op3(op2(x, y)), op3(op2(y, x)))
         g = FunctionGraph([x, y, z], [e])
         MergeOptimizer().optimize(g)
-        assert str(g) == "[Op1(Op3(Op2(x, y)), Op3(Op2(y, x)))]"
+        assert str(g) == "FunctionGraph(Op1(Op3(Op2(x, y)), Op3(Op2(y, x))))"
 
     def test_merge_outputs(self):
         x, y, z = inputs()
@@ -282,7 +282,7 @@ class TestMergeOptimizer:
         e2 = op3(op2(x, y))
         g = FunctionGraph([x, y, z], [e1, e2])
         MergeOptimizer().optimize(g)
-        assert str(g) == "[*1 -> Op3(Op2(x, y)), *1]"
+        assert str(g) == "FunctionGraph(*1 -> Op3(Op2(x, y)), *1)"
 
     def test_multiple_merges(self):
         x, y, z = inputs()
@@ -295,9 +295,10 @@ class TestMergeOptimizer:
         # note: graph.as_string can only produce the following two possibilities, but if
         # the implementation was to change there are 6 other acceptable answers.
         assert (
-            strg == "[Op1(*1 -> Op1(x, y), Op4(*2 -> Op2(Op3(x), y, z), *1), Op1(*2))]"
+            strg
+            == "FunctionGraph(Op1(*1 -> Op1(x, y), Op4(*2 -> Op2(Op3(x), y, z), *1), Op1(*2)))"
             or strg
-            == "[Op1(*2 -> Op1(x, y), Op4(*1 -> Op2(Op3(x), y, z), *2), Op1(*1))]"
+            == "FunctionGraph(Op1(*2 -> Op1(x, y), Op4(*1 -> Op2(Op3(x), y, z), *2), Op1(*1)))"
         )
 
     def test_identical_constant_args(self):
@@ -313,7 +314,7 @@ class TestMergeOptimizer:
         g = FunctionGraph([x, y, z], [e1])
         MergeOptimizer().optimize(g)
         strg = str(g)
-        assert strg == "[Op1(y, y)]" or strg == "[Op1(z, z)]"
+        assert strg == "FunctionGraph(Op1(y, y))" or strg == "FunctionGraph(Op1(z, z))"
 
     def est_one_assert_merge(self):
         # Merge two nodes, one has assert, the other not.
@@ -494,7 +495,7 @@ class TestEquilibrium:
         )
         opt.optimize(g)
         # print g
-        assert str(g) == "[Op2(x, y)]"
+        assert str(g) == "FunctionGraph(Op2(x, y))"
 
     def test_2(self):
         x, y, z = map(MyVariable, "xyz")
@@ -512,7 +513,7 @@ class TestEquilibrium:
             max_use_ratio=10,
         )
         opt.optimize(g)
-        assert str(g) == "[Op2(x, y)]"
+        assert str(g) == "FunctionGraph(Op2(x, y))"
 
     @theano.change_flags(on_opt_error="ignore")
     def test_low_use_ratio(self):
@@ -538,7 +539,7 @@ class TestEquilibrium:
         finally:
             _logger.setLevel(oldlevel)
         # print 'after', g
-        assert str(g) == "[Op1(x, y)]"
+        assert str(g) == "FunctionGraph(Op1(x, y))"
 
 
 def test_pre_constant_merge_slice():

--- a/tests/gof/test_optdb.py
+++ b/tests/gof/test_optdb.py
@@ -8,6 +8,9 @@ class TestDB:
         class Opt(opt.GlobalOptimizer):  # inheritance buys __hash__
             name = "blah"
 
+            def apply(self, fgraph):
+                pass
+
         db = DB()
         db.register("a", Opt())
 

--- a/tests/gof/test_optdb.py
+++ b/tests/gof/test_optdb.py
@@ -5,7 +5,7 @@ from theano.gof.optdb import DB, opt
 
 class TestDB:
     def test_name_clashes(self):
-        class Opt(opt.Optimizer):  # inheritance buys __hash__
+        class Opt(opt.GlobalOptimizer):  # inheritance buys __hash__
             name = "blah"
 
         db = DB()

--- a/tests/gpuarray/test_cgpukernelbase.py
+++ b/tests/gpuarray/test_cgpukernelbase.py
@@ -54,7 +54,7 @@ class GpuEye(CGpuKernelBase, Op):
 
         return Apply(self, [n, m], [otype()])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         out_shape = [node.inputs[0], node.inputs[1]]
         return [out_shape]
 

--- a/tests/gpuarray/test_dnn.py
+++ b/tests/gpuarray/test_dnn.py
@@ -217,6 +217,7 @@ def run_dnn_conv_invalid_precision(ndim):
 
     def dnn_conv(precision, border_mode, direction_hint):
         return dnn_conv_func(
+            None,
             img,
             kerns,
             border_mode=border_mode,
@@ -279,8 +280,8 @@ def test_dnn_conv3d_mixed_dtype():
         assert conv.owner.inputs[1].dtype == dt
         assert conv.owner.inputs[2].dtype == dt
 
-    assert_types(dnn.dnn_conv3d(md, mf, precision="as_input"))
-    assert_types(dnn.dnn_conv3d(mf, md, precision="as_input"))
+    assert_types(dnn.dnn_conv3d(None, md, mf, precision="as_input"))
+    assert_types(dnn.dnn_conv3d(None, mf, md, precision="as_input"))
     assert_types(dnn.dnn_gradweight3d(mf, md, kerns_shp=mf.shape, precision="as_input"))
     assert_types(dnn.dnn_gradweight3d(md, mf, kerns_shp=mf.shape, precision="as_input"))
     assert_types(dnn.dnn_gradinput3d(mf, md, img_shp=mf.shape, precision="as_input"))
@@ -1251,11 +1252,11 @@ def run_conv_small_batched_vs_multicall(inputs_shape, filters_shape, batch_sub):
         dnn_func = dnn.dnn_conv3d
     else:
         dnn_func = dnn.dnn_conv
-    conv = dnn_func(img=inputs, kerns=filters, algo=algo)
+    conv = dnn_func(None, img=inputs, kerns=filters, algo=algo)
     # Just compute first and last outputs, to reduce execution time.
-    sub_conv_top = dnn_func(img=inputs[:batch_sub], kerns=filters, algo=algo)
+    sub_conv_top = dnn_func(None, img=inputs[:batch_sub], kerns=filters, algo=algo)
     sub_conv_bottom = dnn_func(
-        img=inputs[(batch_size - batch_sub) :], kerns=filters, algo=algo
+        None, img=inputs[(batch_size - batch_sub) :], kerns=filters, algo=algo
     )
     f = theano.function([], [conv, sub_conv_top, sub_conv_bottom], mode=mode_with_gpu)
     res_all, res_batch_top, res_batch_bottom = f()
@@ -1306,6 +1307,7 @@ def test_conv3d_fwd():
 
         # Compile a theano function for the cuDNN implementation
         conv = dnn.dnn_conv3d(
+            None,
             img=inputs,
             kerns=filters,
             border_mode=border_mode,
@@ -1367,6 +1369,7 @@ def test_conv3d_bwd():
 
         # Compile a theano function for the cuDNN implementation
         conv = dnn.dnn_conv3d(
+            None,
             img=inputs,
             kerns=filters,
             border_mode=border_mode,

--- a/tests/gpuarray/test_opt.py
+++ b/tests/gpuarray/test_opt.py
@@ -915,7 +915,7 @@ class TestConv_opt:
         # so it use the default mode.
         if op is None:
             # No convolutions optimization takes place
-            assert optimiser.transform(conv_op.owner) is None
+            assert optimiser.transform(None, conv_op.owner) is None
         else:
             ref_func = theano.function([], conv_op, mode=mode_with_gpu)
             with theano.change_flags(mode=mode):
@@ -991,7 +991,7 @@ class TestConv_opt:
         # so it use the default mode.
         if op is None:
             # No convolutions optimization takes place
-            assert optimiser.transform(conv_op.owner) is None
+            assert optimiser.transform(None, conv_op.owner) is None
             return
         elif op != "conv3d2d":
             with theano.change_flags(mode=mode):

--- a/tests/sandbox/linalg/test_linalg.py
+++ b/tests/sandbox/linalg/test_linalg.py
@@ -159,5 +159,5 @@ def test_matrix_inverse_solve():
     A = theano.tensor.dmatrix("A")
     b = theano.tensor.dmatrix("b")
     node = matrix_inverse(A).dot(b).owner
-    [out] = inv_as_solve.transform(node)
+    [out] = inv_as_solve.transform(None, node)
     assert isinstance(out.owner.op, Solve)

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -173,12 +173,12 @@ class TestComposite:
         gof.DualLinker().accept(g).make_function()
 
         assert str(g) == (
-            "[*1 -> Composite{((i0 + i1) + i2),"
+            "FunctionGraph(*1 -> Composite{((i0 + i1) + i2),"
             " (i0 + (i1 * i2)), (i0 / i1), "
             "(i0 // Constant{5}), "
             "(-i0), (i0 - i1), ((i0 ** i1) + (-i2)),"
             " (i0 % Constant{3})}(x, y, z), "
-            "*1::1, *1::2, *1::3, *1::4, *1::5, *1::6, *1::7]"
+            "*1::1, *1::2, *1::3, *1::4, *1::5, *1::6, *1::7)"
         )
 
     def test_make_node_continue_graph(self):

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -4731,7 +4731,7 @@ for{cpu,scan_fn}.2 [id H] ''
         A = tensor.vector("A")
 
         # Build a MonitorMode that counts how many values are greater than 10
-        def detect_large_outputs(i, node, fn):
+        def detect_large_outputs(fgraph, i, node, fn):
             for output in fn.outputs:
                 if isinstance(output[0], np.ndarray):
                     detect_large_outputs.large_count += (output[0] > 10).sum()

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -1053,35 +1053,6 @@ class TestScan:
         vu2 = asarrayX(rng.rand(3, 3))
         vy0 = asarrayX(rng.rand(3, 2))
         vy1 = asarrayX(rng.rand(2))
-
-        # Their is a bug when floatX=float32 when we remove this line.
-        # The trace back is:
-        # Traceback (most recent call last):
-        #  File "/u/bastienf/repos/Theano/tests/scan/test_basic.py", line 434, in test_shared_arguments_with_updates
-        #    theano_y0,theano_y1,theano_y2 = f10(vu2, vy0)
-        #  File "/u/bastienf/repos/theano/compile/function/types.py", line 480, in __call__
-        #    self.fn()
-        #  File "/u/bastienf/repos/theano/compile/profilemode.py", line 59, in profile_f
-        #    raise_with_op(node)
-        #  File "/u/bastienf/repos/theano/compile/profilemode.py", line 52, in profile_f
-        #    th()
-        #  File "/u/bastienf/repos/theano/gof/cc.py", line 1141, in <lambda>
-        #    thunk = lambda p = p, i = node_input_storage, o = node_output_storage, n = node: p(n, [x[0] for x in i], o)
-        #  File "/u/bastienf/repos/theano/scan/op.py", line 922, in perform
-        #    inplace_map)
-        #  File "/u/bastienf/repos/theano/scan/basic.py", line 1054, in scan
-        #    something = fn(*fn_args)
-        #  File "/u/bastienf/repos/theano/compile/function/types.py", line 458, in __call__
-        #    s.storage[0] = s.type.filter(arg, strict=s.strict)
-        #  File "/u/bastienf/repos/theano/tensor/basic.py", line 415, in filter
-        #    data = theano._asarray(data, dtype = self.dtype) #TODO - consider to pad shape with ones
-        #  File "/u/bastienf/repos/theano/misc/safe_asarray.py", line 30, in _asarray
-        #    rval = numpy.asarray(a, dtype=dtype, order=order)
-        #  File "/u/lisa/local/byhost/ceylon.iro.umontreal.ca//lib64/python2.5/site-packages/numpy/core/numeric.py", line 230, in asarray
-        #    return array(a, dtype, copy=False, order=order)
-        # TypeError: ('__array__() takes no arguments (1 given)', <Scan object at 0x3dbbf90>(?_steps, u1, u2, y0, y1, 0.0, W1, W2), 'Sequence id of Apply node=0')
-        #
-        #  This don't seam to be a theano related bug...
         vu1 = asarrayX(rng.rand(3, 2))
 
         W1 = theano.shared(vW1, "W1")

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -338,7 +338,7 @@ class TestVerifyGradSparse:
             else:
                 return (gz,)
 
-        def infer_shape(self, node, shapes):
+        def infer_shape(self, fgraph, node, shapes):
             return [shapes[0]]
 
     def test_grad_fail(self):

--- a/tests/tensor/test_blas.py
+++ b/tests/tensor/test_blas.py
@@ -24,6 +24,7 @@ import theano.tensor.blas_scipy
 from tests import unittest_tools
 from tests.tensor.utils import inplace_func
 from theano import In, config, shared
+from theano.gof.fg import FunctionGraph
 from theano.tensor import as_tensor_variable, inplace
 from theano.tensor.blas import (
     Dot22,
@@ -528,11 +529,14 @@ class TestGemmNoFlags:
 def test_res_is_a():
     X, Y, Z, a, b = XYZab()
 
-    assert not res_is_a(a, tt.sqrt)
-    assert not res_is_a(a + a, tt.sqrt)
-    assert res_is_a(tt.sqrt(a + a), tt.sqrt)
+    assert not res_is_a(None, a, tt.sqrt)
+    assert not res_is_a(None, a + a, tt.sqrt)
+    assert res_is_a(None, tt.sqrt(a + a), tt.sqrt)
 
-    # leave the maxclients  stuff untested because it requires being in an fgraph.
+    sqrt_term = tt.sqrt(a + a)
+    fg = FunctionGraph([a], [2 * sqrt_term], clone=False)
+    assert res_is_a(fg, sqrt_term, tt.sqrt, 2)
+    assert not res_is_a(fg, sqrt_term, tt.sqrt, 0)
 
 
 class TestAsScalar:
@@ -731,15 +735,20 @@ def test_gemm_canonicalize():
     w = tt.col("w")
 
     can = []
-    _gemm_canonicalize(X + Y + Z, 1.0, can, 0)
+    fg = FunctionGraph([X, Y, Z], [X + Y + Z], clone=False)
+    _gemm_canonicalize(fg, fg.outputs[0], 1.0, can, 0)
     assert can == [(1.0, X), (1.0, Y), (1.0, Z)]
+    fg.disown()
 
     can = []
-    _gemm_canonicalize(X + Y + u, 1.0, can, 0)
+    fg = FunctionGraph([X, Y, u], [X + Y + u], clone=False)
+    _gemm_canonicalize(fg, fg.outputs[0], 1.0, can, 0)
     assert can == [(1.0, X), (1.0, Y), (1.0, u)], can
+    fg.disown()
 
     can = []
-    _gemm_canonicalize(X + Y + v, 1.0, can, 0)
+    fg = FunctionGraph([X, Y, v], [X + Y + v], clone=False)
+    _gemm_canonicalize(fg, fg.outputs[0], 1.0, can, 0)
     # [(1.0, X), (1.0, Y), (1.0, InplaceDimShuffle{x,0}(v))]
     assert can[:2] == [(1.0, X), (1.0, Y)]
     assert isinstance(can[2], tuple)
@@ -748,23 +757,30 @@ def test_gemm_canonicalize():
     assert can[2][1].owner
     assert isinstance(can[2][1].owner.op, tt.DimShuffle)
     assert can[2][1].owner.inputs == [v]
+    fg.disown()
 
     can = []
-    _gemm_canonicalize(X + Y + w, 1.0, can, 0)
+    fg = FunctionGraph([X, Y, w], [X + Y + w], clone=False)
+    _gemm_canonicalize(fg, fg.outputs[0], 1.0, can, 0)
     assert can == [(1.0, X), (1.0, Y), (1.0, w)], can
+    fg.disown()
 
     can = []
-    _gemm_canonicalize(a * X + Y - b * Z * c, 1.0, can, 0)
+    fg = FunctionGraph([a, X, Y, b, Z, c], [a * X + Y - b * Z * c], clone=False)
+    _gemm_canonicalize(fg, fg.outputs[0], 1.0, can, 0)
     assert can[0] == (a, X)
     assert can[1] == (1.0, Y)
     assert can[2][0].owner.op == tt.mul
     assert can[2][0].owner.inputs[0].owner.op == tt.neg
     assert can[2][0].owner.inputs[0].owner.inputs[0] == c
     assert can[2][0].owner.inputs[1] == b
+    fg.disown()
 
     can = []
-    _gemm_canonicalize((-d) * X - (a * X + Y - b * Z * c), 1.0, can, 0)
-    # print can
+    fg = FunctionGraph(
+        [a, X, Y, b, Z, c, d], [(-d) * X - (a * X + Y - b * Z * c)], clone=False
+    )
+    _gemm_canonicalize(fg, fg.outputs[0], 1.0, can, 0)
     assert can[0][0].owner.op == tt.neg
     assert can[0][0].owner.inputs[0] == d
     assert can[0][1] == X
@@ -773,6 +789,7 @@ def test_gemm_canonicalize():
     assert can[2] == (-1.0, Y)
     assert can[3][0].owner.op == tt.mul
     assert can[3][0].owner.inputs == [c, b]
+    fg.disown()
 
 
 def test_gemm_factor():

--- a/tests/tensor/test_blas.py
+++ b/tests/tensor/test_blas.py
@@ -1218,7 +1218,7 @@ def test_local_dot22_to_dot22scalar():
             tt.mul(_dot22(A, A), (r * m), (m * x)),
         ]
     ):
-        node2 = local_dot22_to_dot22scalar.transform(node.owner)
+        node2 = local_dot22_to_dot22scalar.transform(None, node.owner)
         assert node2
         f = theano.function(
             [x, y, z, m, r, A], node, mode=mode, on_unused_input="ignore"
@@ -1806,49 +1806,53 @@ class TestGer(unittest_tools.OptimizationTestMixin):
     def test_b_0_triggers_ger(self):
         # test local_gemm_to_ger opt
         assert local_gemm_to_ger.transform(
+            None,
             gemm_no_inplace(
                 self.A,
                 self.a,
                 self.x.dimshuffle(0, "x"),
                 self.y.dimshuffle("x", 0),
                 self.b(0),
-            ).owner
+            ).owner,
         )
 
     def test_b_1_triggers_ger(self):
         # test local_gemm_to_ger opt
         assert local_gemm_to_ger.transform(
+            None,
             gemm_no_inplace(
                 self.A,
                 self.a,
                 self.x.dimshuffle(0, "x"),
                 self.y.dimshuffle("x", 0),
                 self.b(1),
-            ).owner
+            ).owner,
         )
 
     def test_b_other_does_not_triggers_ger(self):
         # test local_gemm_to_ger opt
         assert not local_gemm_to_ger.transform(
+            None,
             gemm_no_inplace(
                 self.A,
                 self.a,
                 self.x.dimshuffle(0, "x"),
                 self.y.dimshuffle("x", 0),
                 self.b(1.5),
-            ).owner
+            ).owner,
         )
 
     def test_b_nonconst_does_not_triggers_ger(self):
         # test local_gemm_to_ger opt
         assert not local_gemm_to_ger.transform(
+            None,
             gemm_no_inplace(
                 self.A,
                 self.a,
                 self.x.dimshuffle(0, "x"),
                 self.y.dimshuffle("x", 0),
                 self.a,
-            ).owner
+            ).owner,
         )
 
     def test_outer(self):

--- a/tests/tensor/test_opt.py
+++ b/tests/tensor/test_opt.py
@@ -2874,15 +2874,16 @@ class TestLocalSubtensorLift:
         z = tt.matrix("z")
         f = function([x, y, z], tt.exp(x + y + z)[0], mode=mode_opt)
 
-        # Check stacktrace was copied over correctly after opt was applied
-        assert check_stack_trace(f, ops_to_check=[Subtensor, tt.DimShuffle])
-
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tt.Subtensor)
         assert isinstance(prog[1].op, tt.DimShuffle)
         assert isinstance(prog[2].op, tt.Subtensor)
         assert isinstance(prog[3].op.scalar_op, scal.Composite)  # Composite{add,add}
         assert len(prog) == 4
+
+        # Check stacktrace was copied over correctly after opt was applied
+        assert check_stack_trace(f, ops_to_check=[Subtensor])
+
         # let debugmode test something
         f([[0, 1], [2, 3]], 4, [[4, 5], [6, 7]])
 
@@ -2893,15 +2894,16 @@ class TestLocalSubtensorLift:
         z = tt.matrix("z")
         f = function([x, y, z], tt.exp(x + y + z)[0:2], mode=mode_opt)
 
-        # Check stacktrace was copied over correctly after opt was applied
-        assert check_stack_trace(f, ops_to_check=[Subtensor, tt.DimShuffle])
-
         prog = f.maker.fgraph.toposort()
         assert isinstance(prog[0].op, tt.Subtensor)
         assert isinstance(prog[1].op, tt.DimShuffle)
         assert isinstance(prog[2].op, tt.Subtensor)
         assert isinstance(prog[3].op.scalar_op, scal.Composite)  # Composite{add,add}
         assert len(prog) == 4
+
+        # Check stacktrace was copied over correctly after opt was applied
+        assert check_stack_trace(f, ops_to_check=[Subtensor])
+
         # let debugmode test something
         f([[0, 1], [2, 3]], 4, [[4, 5], [6, 7]])
 

--- a/tests/tensor/test_opt.py
+++ b/tests/tensor/test_opt.py
@@ -196,7 +196,7 @@ class TestDimshuffleLift:
             "InplaceDimShuffle{x,x}(TensorConstant{84})))))"
         )
         assert str(g) == init_str_g
-        new_out = local_dimshuffle_lift.transform(g.outputs[0].owner)[0]
+        new_out = local_dimshuffle_lift.transform(g, g.outputs[0].owner)[0]
         new_g = FunctionGraph(g.inputs, [new_out])
         opt_str_g = (
             "FunctionGraph(Elemwise{mul,no_inplace}(Elemwise{add,no_inplace}"
@@ -5050,7 +5050,7 @@ class TestShapeOptimizer:
         identity_shape = IdentityShape()
 
         @gof.local_optimizer([IdentityNoShape])
-        def local_identity_noshape_to_identity_shape(node):
+        def local_identity_noshape_to_identity_shape(fgraph, node):
             """Optimization transforming the first Op into the second"""
             if isinstance(node.op, IdentityNoShape):
                 return [identity_shape(node.inputs[0])]
@@ -7433,18 +7433,18 @@ def test_local_add_specialize():
     # test of non-zero dimension
     a = tt.vector()
     s = tt.add(tt.zeros_like(a))
-    assert local_add_specialize.transform(s.owner)
+    assert local_add_specialize.transform(None, s.owner)
 
     # test of 0-d
     a = tt.scalar()
     s = tt.add(tt.zeros_like(a))
-    assert local_add_specialize.transform(s.owner)
+    assert local_add_specialize.transform(None, s.owner)
 
     # Test when the 0 input is forcing upcasting
     a = tt.constant(0, dtype="int64")
     b = tt.constant(1, dtype="int32")
     s = a + b
-    transformed = local_add_specialize.transform(s.owner)
+    transformed = local_add_specialize.transform(None, s.owner)
     assert transformed
     assert transformed[0].type == s.type
 

--- a/tests/tensor/test_opt.py
+++ b/tests/tensor/test_opt.py
@@ -5027,7 +5027,7 @@ class TestShapeOptimizer:
                 (out,) = out_
                 out[0] = x.copy()
 
-            # def infer_shape(self, node, (xshp,)):
+            # def infer_shape(self, fgraph, node, (xshp,)):
             # return [tuple([self.shape_i(i)(r) for i in range(r.ndim)])]
 
         identity_noshape = IdentityNoShape()
@@ -5044,7 +5044,7 @@ class TestShapeOptimizer:
                 (out,) = out_
                 out[0] = x.copy()
 
-            def infer_shape(self, node, xshp_):
+            def infer_shape(self, fgraph, node, xshp_):
                 # Could also just return.
                 (xshp,) = xshp_
                 return (xshp,)

--- a/tests/tensor/test_opt.py
+++ b/tests/tensor/test_opt.py
@@ -4916,7 +4916,7 @@ class TestLocalUselessIncSubtensorAlloc:
         assert check_stack_trace(f2, ops_to_check="last")
 
 
-class TestShapeoptimizer:
+class TestShapeOptimizer:
     def setup_method(self):
         utt.seed_rng()
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -247,32 +247,6 @@ def test_debugprint():
 
     assert s == reference
 
-    # test clients
-    s = StringIO()
-    # We must force the mode as otherwise it can change the clients order
-    f = theano.function([A, B, D], [A + B, A + B - D], mode="FAST_COMPILE")
-    debugprint(f, file=s, print_clients=True)
-    s = s.getvalue()
-    # The additional white space are needed!
-    reference = (
-        "\n".join(
-            [
-                "Elemwise{add,no_inplace} [id A] ''   0 clients:[('output', ''), ('[id C]', 1)]",
-                " |A [id D]",
-                " |B [id E]",
-                "Elemwise{sub,no_inplace} [id C] ''   1",
-                " |Elemwise{add,no_inplace} [id A] ''   0 clients:[('output', ''), ('[id C]', 1)]",
-                " |D [id F]",
-            ]
-        )
-        + "\n"
-    )
-    if s != reference:
-        print("--" + s + "--")
-        print("--" + reference + "--")
-
-    assert s == reference
-
 
 def test_scan_debugprint1():
     k = tensor.iscalar("k")

--- a/theano/breakpoint.py
+++ b/theano/breakpoint.py
@@ -145,7 +145,7 @@ class PdbBreakpoint(Op):
     def grad(self, inputs, output_gradients):
         return [DisconnectedType()()] + output_gradients
 
-    def infer_shape(self, inputs, input_shapes):
+    def infer_shape(self, fgraph, inputs, input_shapes):
         # Return the shape of every input but the condition (first input)
         return input_shapes[1:]
 

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -780,7 +780,7 @@ class OpFromGraph(Op):
 
         return list(map(list, cpmat_self))
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
 
         out_shp = infer_shape(self.local_outputs, self.local_inputs, shapes)
 

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -819,7 +819,7 @@ class OpFromGraph(Op):
 
 
 @local_optimizer([OpFromGraph])
-def inline_ofg_expansion(node):
+def inline_ofg_expansion(fgraph, node):
     """
     This optimization expands internal graph of OpFromGraph.
     Only performed if node.op.is_inline == True

--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -2042,7 +2042,7 @@ class _Linker(gof.link.LocalLinker):
                             exc_type, exc_value, exc_trace = sys.exc_info()
                             exc_value = new_e
                             raise_with_op(
-                                node, thunk_c, (exc_type, exc_value, exc_trace)
+                                fgraph, node, thunk_c, (exc_type, exc_value, exc_trace)
                             )
 
                     if thunk_py:
@@ -2154,7 +2154,7 @@ class _Linker(gof.link.LocalLinker):
                             exc_type, exc_value, exc_trace = sys.exc_info()
                             exc_value = new_e
                             raise_with_op(
-                                node, thunk_c, (exc_type, exc_value, exc_trace)
+                                fgraph, node, thunk_c, (exc_type, exc_value, exc_trace)
                             )
 
                         for r in node.outputs:
@@ -2222,7 +2222,7 @@ class _Linker(gof.link.LocalLinker):
                                 try:
                                     thunk_c()
                                 except Exception:
-                                    raise_with_op(node, thunk_c)
+                                    raise_with_op(fgraph, node, thunk_c)
 
                             _logger.debug(
                                 f"{i} - calling _check_preallocated_output "

--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -53,11 +53,6 @@ class NoDuplicateOptWarningFilter(logging.Filter):
 _logger.addFilter(NoDuplicateOptWarningFilter())
 
 
-########################
-#
-# Exceptions
-#
-########################
 class DebugModeError(Exception):
     """
     Generic Exception raised to indicate an internal theano problem.
@@ -360,13 +355,6 @@ class InvalidValueError(DebugModeError):
         context        = ...
 {context}
         """
-
-
-########################
-#
-# Private Functions
-#
-########################
 
 
 def str_diagnostic(expected, value, rtol, atol):
@@ -2592,13 +2580,6 @@ class _Maker(FunctionMaker):  # inheritance buys a few helper functions
             )
             for i in self.inputs
         ]
-
-
-########################
-#
-# API symbol: DebugMode
-#
-########################
 
 
 class DebugMode(Mode):

--- a/theano/compile/function/pfunc.py
+++ b/theano/compile/function/pfunc.py
@@ -78,9 +78,6 @@ def rebuild_collect_shared(
         Also appends all shared variables met along the way to shared inputs,
         and their default_update (if applicable) to update_d and update_expr.
 
-        v can have an fgraph attached to it, case in which we want to clone
-        constants (to avoid having a constant belonging to two fgraphs).
-
         """
         # this co-recurses with clone_a
         assert v is not None
@@ -122,9 +119,7 @@ def rebuild_collect_shared(
                             )
                         update_d[v] = v_update
                         update_expr.append((v, v_update))
-        if not copy_inputs_over or (isinstance(v, Constant) and hasattr(v, "fgraph")):
-            # Cloning shared variables implies copying their underlying
-            # memory buffer ?? No.
+        if not copy_inputs_over:
             return clone_d.setdefault(v, v.clone())
         else:
             return clone_d.setdefault(v, v)

--- a/theano/compile/function/types.py
+++ b/theano/compile/function/types.py
@@ -65,7 +65,7 @@ def view_tree_set(fgraph, v, treeset):
 
     """
     treeset.add(v)
-    for cl, v_input_pos_to_cl in v.clients:
+    for cl, v_input_pos_to_cl in fgraph.clients[v]:
         if cl == "output":
             continue
         vmap = getattr(cl.op, "view_map", {})

--- a/theano/compile/function/types.py
+++ b/theano/compile/function/types.py
@@ -1454,28 +1454,6 @@ class FunctionMaker:
                         t1 = output_new
                         t2 = f2.outputs[i]
 
-                        # Used to remove "already used by another graph error
-                        def removeAllFgraph(remove):
-                            if hasattr(remove, "fgraph"):
-                                del remove.fgraph
-                            if hasattr(remove, "owner"):
-                                if remove.owner is None:
-                                    pass
-                                else:
-                                    if hasattr(remove.owner, "fgraph"):
-                                        del remove.owner.fgraph
-                                    if hasattr(remove.owner, "inputs"):
-                                        remove.owner.inputs = [
-                                            removeAllFgraph(i)
-                                            for i in remove.owner.inputs
-                                        ]
-                                        for o in remove.owner.outputs:
-                                            if hasattr(o, "fgraph"):
-                                                del o.fgraph
-                            return remove
-
-                        t2 = removeAllFgraph(t2)
-
                         givens = dict(
                             zip(gof.graph.inputs([t1]), gof.graph.inputs([t2]))
                         )

--- a/theano/compile/function/types.py
+++ b/theano/compile/function/types.py
@@ -58,7 +58,7 @@ def alias_root(v):
         return v
 
 
-def view_tree_set(v, treeset):
+def view_tree_set(fgraph, v, treeset):
     """
     Add to `treeset` all variables that are views of v, given that v is
     not a view.
@@ -73,7 +73,7 @@ def view_tree_set(v, treeset):
         for opos, iposlist in chain(vmap.items(), dmap.items()):
             if v_input_pos_to_cl in iposlist:
                 if cl.outputs[opos] not in treeset:
-                    view_tree_set(cl.outputs[opos], treeset)
+                    view_tree_set(fgraph, cl.outputs[opos], treeset)
 
 
 def infer_reuse_pattern(fgraph, outputs_to_disown):
@@ -89,7 +89,7 @@ def infer_reuse_pattern(fgraph, outputs_to_disown):
     """
     rval = set()
     for o in outputs_to_disown:
-        view_tree_set(alias_root(o), rval)
+        view_tree_set(fgraph, alias_root(o), rval)
     # remove from rval all of the inputs, constants, values.
     rval = {r for r in rval if r.owner is not None}
 
@@ -979,6 +979,7 @@ class Function:
                 if hasattr(self.fn, "thunks"):
                     thunk = self.fn.thunks[self.fn.position_of_error]
                 gof.link.raise_with_op(
+                    self.maker.fgraph,
                     node=self.fn.nodes[self.fn.position_of_error],
                     thunk=thunk,
                     storage_map=getattr(self.fn, "storage_map", None),
@@ -1205,7 +1206,7 @@ def insert_deepcopy(fgraph, wrapped_inputs, wrapped_outputs):
 
     for i in range(len(fgraph.outputs)):
         views_of_output_i = set()
-        view_tree_set(alias_root(fgraph.outputs[i]), views_of_output_i)
+        view_tree_set(fgraph, alias_root(fgraph.outputs[i]), views_of_output_i)
         copied = False
         # do not allow outputs to be aliased
         for j in range(i + 1, len(fgraph.outputs)):

--- a/theano/compile/mode.py
+++ b/theano/compile/mode.py
@@ -93,13 +93,13 @@ predefined_optimizers = {
 
 
 def register_optimizer(name, opt):
-    """Add a `Optimizer` which can be referred to by `name` in `Mode`."""
+    """Add a `GlobalOptimizer` which can be referred to by `name` in `Mode`."""
     if name in predefined_optimizers:
         raise ValueError(f"Optimizer name already taken: {name}")
     predefined_optimizers[name] = opt
 
 
-class AddDestroyHandler(gof.Optimizer):
+class AddDestroyHandler(gof.GlobalOptimizer):
     """
     This optimizer performs two important functions:
 
@@ -134,7 +134,7 @@ class AddDestroyHandler(gof.Optimizer):
         fgraph.attach_feature(gof.DestroyHandler())
 
 
-class AddFeatureOptimizer(gof.Optimizer):
+class AddFeatureOptimizer(gof.GlobalOptimizer):
     """
     This optimizer adds a provided feature to the function graph.
     """
@@ -147,7 +147,7 @@ class AddFeatureOptimizer(gof.Optimizer):
         fgraph.attach_feature(self.feature)
 
 
-class PrintCurrentFunctionGraph(gof.Optimizer):
+class PrintCurrentFunctionGraph(gof.GlobalOptimizer):
     """
     This optimizer is for debugging.
 

--- a/theano/compile/mode.py
+++ b/theano/compile/mode.py
@@ -146,6 +146,9 @@ class AddFeatureOptimizer(gof.GlobalOptimizer):
         super().add_requirements(fgraph)
         fgraph.attach_feature(self.feature)
 
+    def apply(self, fgraph):
+        pass
+
 
 class PrintCurrentFunctionGraph(gof.GlobalOptimizer):
     """

--- a/theano/compile/monitormode.py
+++ b/theano/compile/monitormode.py
@@ -7,8 +7,7 @@ from theano.compile.mode import Mode
 
 
 class MonitorMode(Mode):
-    """
-    `MonitorMode` is a debug mode to easily step through function execution.
+    """A debug mode that facilitates stepping through function execution.
 
     Its default behavior is to behave like the 'FAST_RUN' mode. By providing
     either a `pre_func` (called before a node is executed) or a `post_func`
@@ -22,12 +21,13 @@ class MonitorMode(Mode):
     ----------
     pre_func
         A function to call before executing a thunk, with arguments:
+        - the `FunctionGraph`
         - the thunk index
-        - the Apply node
+        - the `Apply` node
         - the thunk to be called
     post_func
-        A function to call after executing a thunk, with the same three
-        arguments as `pre_func`.
+        A function to call after executing a thunk, with the same arguments as
+        `pre_func`.
     optimizer
         The optimizer to use. One may use for instance 'fast_compile' to skip
         optimizations.
@@ -64,16 +64,16 @@ class MonitorMode(Mode):
         self.post_func = post_func
         super().__setstate__((lnk, opt))
 
-    def eval(self, i, node, fn):
+    def eval(self, fgraph, i, node, fn):
         """
         The method that calls the thunk `fn`.
 
         """
         if self.pre_func is not None:
-            self.pre_func(i, node, fn)
+            self.pre_func(fgraph, i, node, fn)
         fn()
         if self.post_func is not None:
-            self.post_func(i, node, fn)
+            self.post_func(fgraph, i, node, fn)
 
     def clone(self, link_kwargs=None, optimizer="", **kwargs):
         """
@@ -94,7 +94,7 @@ class MonitorMode(Mode):
         return new_mode
 
 
-def detect_nan(i, node, fn):
+def detect_nan(fgraph, i, node, fn):
     for output in fn.outputs:
         if (
             not isinstance(output[0], np.random.RandomState)

--- a/theano/compile/profiling.py
+++ b/theano/compile/profiling.py
@@ -1079,7 +1079,7 @@ class ProfileStats:
             # Initial executable_nodes
             executable_nodes = set()
             for var in fgraph.inputs:
-                for c, _ in var.clients:
+                for c, _ in fgraph.clients[var]:
                     if c != "output":
                         deps = c.inputs + c.destroy_dependencies
                         if all(compute_map[v][0] for v in deps):
@@ -1205,7 +1205,7 @@ class ProfileStats:
                         done_dict[frozen_set] = max_mem_count
 
                         for var in node.outputs:
-                            for c, _ in var.clients:
+                            for c, _ in fgraph.clients[var]:
                                 if c != "output":
                                     deps = c.inputs + c.destroy_dependencies
                                     if all(compute_map[v][0] for v in deps):

--- a/theano/d3viz/formatting.py
+++ b/theano/d3viz/formatting.py
@@ -146,7 +146,7 @@ class PyDotFormatter:
             __node_id = self.__node_id(node)
             nparams["name"] = __node_id
             nparams["label"] = apply_label(node)
-            nparams["profile"] = apply_profile(node, profile)
+            nparams["profile"] = apply_profile(fgraph, node, profile)
             nparams["node_type"] = "apply"
             nparams["apply_op"] = nparams["label"]
             nparams["shape"] = self.shapes["apply"]
@@ -298,11 +298,11 @@ def apply_label(node):
     return node.op.__class__.__name__
 
 
-def apply_profile(node, profile):
+def apply_profile(fgraph, node, profile):
     """Return apply profiling informaton."""
     if not profile or profile.fct_call_time == 0:
         return None
-    time = profile.apply_time.get(node, 0)
+    time = profile.apply_time.get((fgraph, node), 0)
     call_time = profile.fct_call_time
     return [time, call_time]
 

--- a/theano/d3viz/formatting.py
+++ b/theano/d3viz/formatting.py
@@ -121,13 +121,12 @@ class PyDotFormatter:
         self.__nodes = {}
 
         profile = None
+
         if isinstance(fct, Function):
             profile = getattr(fct, "profile", None)
-            outputs = fct.maker.fgraph.outputs
-            topo = fct.maker.fgraph.toposort()
+            fgraph = fct.maker.fgraph
         elif isinstance(fct, gof.FunctionGraph):
-            outputs = fct.outputs
-            topo = fct.toposort()
+            fgraph = fct
         else:
             if isinstance(fct, gof.Variable):
                 fct = [fct]
@@ -135,9 +134,10 @@ class PyDotFormatter:
                 fct = fct.outputs
             assert isinstance(fct, (list, tuple))
             assert all(isinstance(v, gof.Variable) for v in fct)
-            fct = gof.FunctionGraph(inputs=gof.graph.inputs(fct), outputs=fct)
-            outputs = fct.outputs
-            topo = fct.toposort()
+            fgraph = gof.FunctionGraph(inputs=gof.graph.inputs(fct), outputs=fct)
+
+        outputs = fgraph.outputs
+        topo = fgraph.toposort()
         outputs = list(outputs)
 
         # Loop over apply nodes
@@ -204,7 +204,7 @@ class PyDotFormatter:
             for id, var in enumerate(node.outputs):
                 var_id = self.__node_id(var)
 
-                if var in outputs or len(var.clients) == 0:
+                if var in outputs or len(fgraph.clients[var]) == 0:
                     vparams = {
                         "name": var_id,
                         "label": var_label(var),
@@ -213,7 +213,7 @@ class PyDotFormatter:
                         "tag": var_tag(var),
                         "style": "filled",
                     }
-                    if len(var.clients) == 0:
+                    if len(fgraph.clients[var]) == 0:
                         vparams["fillcolor"] = self.node_colors["unused"]
                     else:
                         vparams["fillcolor"] = self.node_colors["output"]

--- a/theano/gof/__init__.py
+++ b/theano/gof/__init__.py
@@ -24,6 +24,7 @@ from theano.gof.op import (
 from theano.gof.opt import (
     CheckStackTraceOptimization,
     EquilibriumOptimizer,
+    GlobalOptimizer,
     LocalOptGroup,
     LocalOptimizer,
     MergeOptimizer,
@@ -31,7 +32,6 @@ from theano.gof.opt import (
     OpKeyOptimizer,
     OpRemove,
     OpSub,
-    Optimizer,
     PatternSub,
     SeqOptimizer,
     TopoOptimizer,

--- a/theano/gof/compilelock.py
+++ b/theano/gof/compilelock.py
@@ -255,7 +255,7 @@ def lock(tmp_dir, timeout=notset, min_wait=None, max_wait=None, verbosity=1):
                                 msg = f"process '{read_owner.split('_')[0]}'"
                             _logger.warning(
                                 f"Overriding existing lock by {msg} "
-                                "(I am process '{my_pid}')",
+                                f"(I am process '{my_pid}')",
                             )
                         get_lock.unlocker.unlock(force=True)
                         continue
@@ -270,7 +270,7 @@ def lock(tmp_dir, timeout=notset, min_wait=None, max_wait=None, verbosity=1):
                         msg = f"process '{read_owner.split('_')[0]}'"
                     _logger.info(
                         f"Waiting for existing lock by {msg} (I am "
-                        "process '{my_pid}')",
+                        f"process '{my_pid}')",
                     )
                     _logger.info(f"To manually release the lock, delete {tmp_dir}")
                     if verbosity <= 1:

--- a/theano/gof/destroyhandler.py
+++ b/theano/gof/destroyhandler.py
@@ -410,7 +410,7 @@ class DestroyHandler(toolbox.Bookkeeper):  # noqa
 
             def recursive_destroys_finder(protected_var):
                 # protected_var is the idx'th input of app.
-                for (app, idx) in protected_var.clients:
+                for (app, idx) in fgraph.clients[protected_var]:
                     if app == "output":
                         continue
                     destroy_maps = getattr(app.op, "destroy_map", {}).values()
@@ -481,7 +481,7 @@ class DestroyHandler(toolbox.Bookkeeper):  # noqa
                 self.fail_validate[app] = InconsistencyError(
                     f"Attempting to destroy indestructible variables: {inp}"
                 )
-            elif len(inp.clients) > 1:
+            elif len(fgraph.clients[inp]) > 1:
                 self.fail_validate[app] = theano.gof.InconsistencyError(
                     "Destroyed variable has more than one client. " + str(reason)
                 )

--- a/theano/gof/fg.py
+++ b/theano/gof/fg.py
@@ -812,11 +812,8 @@ class FunctionGraph(utils.object2):
                         "Inconsistent clients list.", variable, node.inputs[i]
                     )
 
-    def __str__(self):
-        return f"[{', '.join(graph.as_string(self.inputs, self.outputs))}]"
-
     def __repr__(self):
-        return self.__str__()
+        return f"FunctionGraph({', '.join(graph.as_string(self.inputs, self.outputs))})"
 
     def clone(self, check_integrity=True):
         """

--- a/theano/gof/graph.py
+++ b/theano/gof/graph.py
@@ -30,10 +30,8 @@ class Node(object2):
     """A `Node` in a Theano graph.
 
     Currently, graphs contain two kinds of `Nodes`: `Variable`s and `Apply`s.
-    Edges in the graph are not explicitly represented.
-    Instead each `Node` keeps track of its parents via
-    `Variable.owner` / `Apply.inputs` and its children
-    via Variable.clients / Apply.outputs.
+    Edges in the graph are not explicitly represented.  Instead each `Node`
+    keeps track of its parents via `Variable.owner` / `Apply.inputs`.
 
     """
 
@@ -287,46 +285,46 @@ class Variable(Node):
     - :literal:`type` a `Type` instance defining the kind of value this
       `Variable` can have,
 
-    - :literal:`owner` either None (for graph roots) or the `Apply` instance
+    - :literal:`owner` either `None` (for graph roots) or the `Apply` instance
       of which `self` is an output,
 
     - :literal:`index` the integer such that :literal:`owner.outputs[index] is
-      this_variable` (ignored if `owner` is None),
+      this_variable` (ignored if `owner` is `None`),
 
     - :literal:`name` a string to use in pretty-printing and debugging.
 
-    There are a few kinds of Variables to be aware of: A Variable which is the
-    output of a symbolic computation has a reference to the Apply instance to
+    There are a few kinds of `Variable`s to be aware of: A `Variable` which is the
+    output of a symbolic computation has a reference to the `Apply` instance to
     which it belongs (property: owner) and the position of itself in the owner's
     output list (property: index).
 
     - `Variable` (this base type) is typically the output of a symbolic
       computation.
 
-    - `Constant` (a subclass) which adds a default and un-replaceable
+    - `Constant`: a subclass which adds a default and un-replaceable
       :literal:`value`, and requires that owner is None.
 
-    - `TensorVariable` subclass of Variable that represents a numpy.ndarray
+    - `TensorVariable` subclass of `Variable` that represents a `numpy.ndarray`
        object.
 
-    - `TensorSharedVariable` Shared version of TensorVariable.
+    - `TensorSharedVariable`: a shared version of `TensorVariable`.
 
-    - `SparseVariable` subclass of Variable that represents
-      a scipy.sparse.{csc,csr}_matrix object.
+    - `SparseVariable`: a subclass of `Variable` that represents
+      a `scipy.sparse.{csc,csr}_matrix` object.
 
-    - `GpuArrayVariable` subclass of Variable that represents our object on
-      the GPU that is a subset of numpy.ndarray.
+    - `GpuArrayVariable`: a subclass of `Variable` that represents our object on
+      the GPU that is a subset of `numpy.ndarray`.
 
     - `RandomVariable`.
 
-    A Variable which is the output of a symbolic computation will have an owner
+    A `Variable` which is the output of a symbolic computation will have an owner
     not equal to None.
 
-    Using the Variables' owner field and the Apply nodes' inputs fields, one can
-    navigate a graph from an output all the way to the inputs. The opposite
-    direction is not possible until a FunctionGraph has annotated the Variables
-    with the clients field, ie, before the compilation process has begun a
-    Variable does not know which Apply nodes take it as input.
+    Using the `Variables`' owner field and the `Apply` nodes' inputs fields,
+    one can navigate a graph from an output all the way to the inputs. The
+    opposite direction is possible with a `FunctionGraph` and its
+    `FunctionGraph.clients` `dict`, which maps `Variable`s to a list of their
+    clients.
 
     Parameters
     ----------

--- a/theano/gof/link.py
+++ b/theano/gof/link.py
@@ -946,7 +946,7 @@ class WrapLinker(Linker):
         For each node in the graph, each linker will provide a
         thunk.  This class makes it possible to iterate over each linker's
         program in parallel.
-    wrapper : lambda (i, i_node, i_thunk1, i_thunk2, ...) : None
+    wrapper : lambda (fgraph, i, i_node, i_thunk1, i_thunk2, ...) : None
         Does some user-defined action for the i'th element of the program.
         i_thunk<n> is the thunk returned by the n'th linker. (If you want
         to run the program, make sure to call the necessary thunks in this
@@ -1060,7 +1060,7 @@ class WrapLinker(Linker):
             pre(self, [input.data for input in input_lists[0]], order, thunk_groups)
             for i, (thunks, node) in enumerate(zip(thunk_groups, order)):
                 try:
-                    wrapper(i, node, *thunks)
+                    wrapper(self.fgraph, i, node, *thunks)
                 except Exception:
                     raise_with_op(self.fgraph, node, *thunks)
 

--- a/theano/gof/link.py
+++ b/theano/gof/link.py
@@ -161,7 +161,7 @@ def raise_with_op(fgraph, node, thunk=None, exc_info=None, storage_map=None):
             shapes = "The thunk don't have an inputs attributes."
             strides = "So we can't access the strides of inputs values"
             scalar_values = "And can't print its inputs scalar value"
-        clients = [[c[0] for c in var.clients] for var in node.outputs]
+        clients = [[c[0] for c in fgraph.clients[var]] for var in node.outputs]
         detailed_err_msg += (
             f"Inputs shapes: {shapes}"
             + f"\nInputs strides: {strides}"

--- a/theano/gof/op.py
+++ b/theano/gof/op.py
@@ -780,7 +780,7 @@ class PureOp:
             " You can use optimizer=fast_compile instead.",
         )
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         """Determine whether or not constant folding should be performed for the given node.
 
         This allows each `PureOp` to determine if it wants to be constant

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -21,8 +21,9 @@ import numpy as np
 
 import theano
 from theano import config
-from theano.gof import graph, op, toolbox, unify
+from theano.gof import graph, op, unify
 from theano.gof.fg import InconsistencyError
+from theano.gof.toolbox import Feature, NodeFinder
 from theano.gof.utils import AssocList, flatten
 from theano.misc.ordered_set import OrderedSet
 
@@ -451,12 +452,11 @@ class SeqOptimizer(GlobalOptimizer, UserList):
         )
 
 
-class MergeFeature:
-    """
-    Keeps track of variables in fgraph that cannot be merged together.
+class MergeFeature(Feature):
+    """Keeps track of variables in a `FunctionGraph` that cannot be merged together.
 
-    That way, the MergeOptimizer can remember the result of the last merge
-    pass on the fgraph.
+    That way, the `MergeOptimizer` can remember the result of the last
+    merge-pass on the `FunctionGraph`.
 
     """
 
@@ -1815,14 +1815,7 @@ class PatternSub(LocalOptimizer):
         )
 
 
-##################
-#   Navigators   #
-##################
-
-# Use the following classes to apply LocalOptimizers
-
-
-class Updater:
+class Updater(Feature):
     def __init__(self, importer, pruner, chin, name=None):
         self.importer = importer
         self.pruner = pruner
@@ -2070,7 +2063,7 @@ class NavigatorOptimizer(GlobalOptimizer):
     def add_requirements(self, fgraph):
         super().add_requirements(fgraph)
         # Added by default
-        # fgraph.attach_feature(toolbox.ReplaceValidate())
+        # fgraph.attach_feature(ReplaceValidate())
         if self.local_opt:
             self.local_opt.add_requirements(fgraph)
 
@@ -2284,10 +2277,10 @@ class OpKeyOptimizer(NavigatorOptimizer):
 
         """
         super().add_requirements(fgraph)
-        fgraph.attach_feature(toolbox.NodeFinder())
+        fgraph.attach_feature(NodeFinder())
 
 
-class ChangeTracker:
+class ChangeTracker(Feature):
     def __init__(self):
         self.changed = False
         self.nb_imported = 0
@@ -3197,7 +3190,7 @@ def check_stack_trace(f_or_fgraph, ops_to_check="last", bug_print="raise"):
     return True
 
 
-class CheckStackTraceFeature:
+class CheckStackTraceFeature(Feature):
     def on_import(self, fgraph, node, reason):
         # In optdb we only register the CheckStackTraceOptimization when
         # theano.config.check_stack_trace is not off but we also double check here.

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -750,8 +750,6 @@ class MergeOptimizer(GlobalOptimizer):
     """
 
     def add_requirements(self, fgraph):
-        # Added by default
-        # fgraph.attach_feature(toolbox.ReplaceValidate())
         if not hasattr(fgraph, "merge_feature"):
             fgraph.attach_feature(MergeFeature())
 
@@ -773,12 +771,12 @@ class MergeOptimizer(GlobalOptimizer):
             success = True
             for pairs_ in pairs_list:
                 # We must check again the equivalence, as the graph
-                # can have changed. If so, doing the replacement can
-                # introduce node that depend on itself.  Doing the
-                # full check of such cycle everytimes is very time
-                # consumming. I think this double check is faster then
+                # could've changed. If so, doing the replacement can
+                # introduce a node that depends on itself.  Doing the
+                # full check of such cycles every time is very time
+                # consuming. I think this double check is faster than
                 # doing the full cycle check. The full cycle check is
-                # skipped by validate() if the graph don't contain
+                # skipped by validate() if the graph doesn't contain
                 # destroyers.
                 var, candidate, merge_mode = pairs_[0]
                 if merge_mode == "new_node" and var in fgraph.variables:
@@ -1404,7 +1402,7 @@ class LocalOptGroup(LocalOptimizer):
                     # Skip opt that have 0 times, they probably wasn't even tried.
                     print(blanc + "  ", f"  {t:.3f}s - {o}", file=stream)
         else:
-            print(blanc, " The Optimizer wasn't successful ", file=stream)
+            print(blanc, " The optimizer wasn't successful ", file=stream)
 
         print(file=stream)
 
@@ -2337,7 +2335,8 @@ class EquilibriumOptimizer(NavigatorOptimizer):
         Global optimizers that apply a list of pre determined optimization.
         They must not traverse the graph as they are called very frequently.
         The MergeOptimizer is one example of optimization that respect this.
-        They are applied after all global optimizer, then when one local optimizer is applied, then after all final optimizer.
+        They are applied after all global optimizers, then when one local
+        optimizer is applied, then after all final optimizers.
 
     """
 
@@ -2873,11 +2872,6 @@ class EquilibriumOptimizer(NavigatorOptimizer):
         )
 
 
-#################
-#   Utilities   #
-#################
-
-
 def _check_chain(r, chain):
     """
     WRITEME
@@ -2910,9 +2904,6 @@ def _check_chain(r, chain):
     return r is not None
 
 
-# _check_chain.n_calls = 0
-
-
 def check_chain(r, *chain):
     """
     WRITEME
@@ -2935,15 +2926,15 @@ def pre_greedy_local_optimizer(fgraph, optimizations, out):
     Its main use is to apply locally constant folding when generating
     the graph of the indices of a subtensor.
 
-    We should not apply optimizations on node that are in fgraph.
-    So we don't optimize node that have an attribute fgraph.
+    Changes should not be applied to nodes that are in an `fgraph`,
+    so we use `fgraph` to prevent that.
 
     Notes
     -----
-    This doesn't do an equilibrium... So if there is optimization
-    like local_upcast_elemwise_constant_inputs in the list, that
-    adds additional node to the inputs of the node, it can
-    be needed to call this function multiple times.
+    This doesn't do an equilibrium optimization, so, if there is optimization
+    like `local_upcast_elemwise_constant_inputs` in the list that adds
+    additional nodes to the inputs of the node, it might be necessary to call
+    this function multiple times.
 
     Parameters
     ----------

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -21,13 +21,12 @@ import numpy as np
 
 import theano
 from theano import config
+from theano.gof import destroyhandler as dh
 from theano.gof import graph, op, unify
 from theano.gof.fg import InconsistencyError
 from theano.gof.toolbox import Feature, NodeFinder
 from theano.gof.utils import AssocList, flatten
 from theano.misc.ordered_set import OrderedSet
-
-from . import destroyhandler as dh
 
 
 _logger = logging.getLogger("theano.gof.opt")

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -43,10 +43,10 @@ class LocalMetaOptimizerSkipAssertionError(AssertionError):
     """
 
 
-class Optimizer:
+class GlobalOptimizer:
     """
 
-    An L{Optimizer} can be applied to an L{FunctionGraph} to transform it.
+    A L{GlobalOptimizer} can be applied to an L{FunctionGraph} to transform it.
     It can represent an optimization or in general any kind
     of transformation you could apply to an L{FunctionGraph}.
 
@@ -73,7 +73,7 @@ class Optimizer:
 
         Applies the optimization to the provided L{FunctionGraph}. It may
         use all the methods defined by the L{FunctionGraph}. If the
-        L{Optimizer} needs to use a certain tool, such as an
+        L{GlobalOptimizer} needs to use a certain tool, such as an
         L{InstanceFinder}, it can do so in its L{add_requirements} method.
 
         """
@@ -125,11 +125,8 @@ class Optimizer:
             )
 
 
-class FromFunctionOptimizer(Optimizer):
-    """
-    WRITEME
-
-    """
+class FromFunctionOptimizer(GlobalOptimizer):
+    """A `GlobalOptimizer` constructed from a given function."""
 
     def __init__(self, fn, requirements=()):
         self.apply = fn
@@ -171,14 +168,8 @@ def inplace_optimizer(f):
     return rval
 
 
-class SeqOptimizer(Optimizer, list):
-    # inherit from Optimizer first to get Optimizer.__hash__
-    """
-
-    Takes a list of L{Optimizer} instances and applies them
-    sequentially.
-
-    """
+class SeqOptimizer(GlobalOptimizer, list):
+    """A `GlobalOptimizer` that applies a list of optimizers sequentially."""
 
     @staticmethod
     def warn(exc, self, optimizer):
@@ -214,7 +205,7 @@ class SeqOptimizer(Optimizer, list):
     def apply(self, fgraph):
         """
 
-        Applies each L{Optimizer} in self in turn.
+        Applies each L{GlobalOptimizer} in self in turn.
 
         """
         l = []
@@ -823,7 +814,7 @@ class MergeFeature:
         return new_inputs
 
 
-class MergeOptimizer(Optimizer):
+class MergeOptimizer(GlobalOptimizer):
     """
     Merges parts of the graph that are identical and redundant.
 
@@ -1945,7 +1936,7 @@ class Updater:
         self.chin = None
 
 
-class NavigatorOptimizer(Optimizer):
+class NavigatorOptimizer(GlobalOptimizer):
     """
     Abstract class.
 
@@ -2835,7 +2826,7 @@ class EquilibriumOptimizer(NavigatorOptimizer):
                 + list(opt.final_optimizers)
                 + list(opt.cleanup_optimizers)
             )
-            if o.print_profile.__code__ is not Optimizer.print_profile.__code__
+            if o.print_profile.__code__ is not GlobalOptimizer.print_profile.__code__
         ]
         if not gf_opts:
             return
@@ -3310,7 +3301,7 @@ class CheckStrackTraceFeature:
                     )
 
 
-class CheckStackTraceOptimization(Optimizer):
+class CheckStackTraceOptimization(GlobalOptimizer):
     """Optimizer that serves to add CheckStackTraceOptimization as an fgraph feature."""
 
     def add_requirements(self, fgraph):

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -22,7 +22,7 @@ import numpy as np
 import theano
 from theano import config
 from theano.gof import destroyhandler as dh
-from theano.gof import graph, op, unify
+from theano.gof import graph, op
 from theano.gof.fg import InconsistencyError
 from theano.gof.toolbox import Feature, NodeFinder
 from theano.gof.utils import AssocList, flatten
@@ -1671,6 +1671,8 @@ class PatternSub(LocalOptimizer):
         constructs out_pattern and performs the replacement.
 
         """
+        from theano.gof import unify
+
         if get_nodes and self.get_nodes is not None:
             for real_node in self.get_nodes(fgraph, node):
                 if real_node == "output":

--- a/theano/gof/opt.py
+++ b/theano/gof/opt.py
@@ -3250,7 +3250,7 @@ def check_stack_trace(f_or_fgraph, ops_to_check="last", bug_print="raise"):
     return True
 
 
-class CheckStrackTraceFeature:
+class CheckStackTraceFeature:
     def on_import(self, fgraph, node, reason):
         # In optdb we only register the CheckStackTraceOptimization when
         # theano.config.check_stack_trace is not off but we also double check here.
@@ -3290,8 +3290,8 @@ class CheckStackTraceOptimization(GlobalOptimizer):
     """Optimizer that serves to add CheckStackTraceOptimization as an fgraph feature."""
 
     def add_requirements(self, fgraph):
-        if not hasattr(fgraph, "CheckStrackTraceFeature"):
-            fgraph.attach_feature(CheckStrackTraceFeature())
+        if not hasattr(fgraph, "CheckStackTraceFeature"):
+            fgraph.attach_feature(CheckStackTraceFeature())
 
     def apply(self, fgraph):
         pass

--- a/theano/gof/optdb.py
+++ b/theano/gof/optdb.py
@@ -43,10 +43,10 @@ class DB:
             tags specified will enable that optimization.
 
         """
-        # N.B. obj is not an instance of class Optimizer.
+        # N.B. obj is not an instance of class `GlobalOptimizer`.
         # It is an instance of a DB.In the tests for example,
         # this is not always the case.
-        if not isinstance(obj, (DB, opt.Optimizer, opt.LocalOptimizer)):
+        if not isinstance(obj, (DB, opt.GlobalOptimizer, opt.LocalOptimizer)):
             raise TypeError("Object cannot be registered in OptDB", obj)
         if name in self.__db__:
             raise ValueError(
@@ -285,8 +285,8 @@ class EquilibriumDB(DB):
 
     Notes
     -----
-    We can put LocalOptimizer and Optimizer as EquilibriumOptimizer
-    suppor both.
+    We can use `LocalOptimizer` and `GlobalOptimizer` since `EquilibriumOptimizer`
+    supports both.
 
     It is probably not a good idea to have ignore_newtrees=False and
     tracks_on_change_inputs=True
@@ -473,7 +473,7 @@ class LocalGroupDB(DB):
 class TopoDB(DB):
     """
 
-    Generate a Global Optimizer of type TopoOptimizer.
+    Generate a `GlobalOptimizer` of type TopoOptimizer.
 
     """
 

--- a/theano/gof/toolbox.py
+++ b/theano/gof/toolbox.py
@@ -235,62 +235,62 @@ class Feature:
 
     """
 
-    def on_attach(self, function_graph):
+    def on_attach(self, fgraph):
         """
-        Called by FunctionGraph.attach_feature, the method that attaches
-        the feature to the FunctionGraph. Since this is called after the
-        FunctionGraph is initially populated, this is where you should
-        run checks on the initial contents of the FunctionGraph.
+        Called by `FunctionGraph.attach_feature`, the method that attaches the
+        feature to the `FunctionGraph`. Since this is called after the
+        `FunctionGraph` is initially populated, this is where you should run
+        checks on the initial contents of the `FunctionGraph`.
 
-        The on_attach method may raise the AlreadyThere exception to cancel
+        The on_attach method may raise the `AlreadyThere` exception to cancel
         the attach operation if it detects that another Feature instance
-        implementing the same functionality is already atttached to the
-        FunctionGraph.
+        implementing the same functionality is already attached to the
+        `FunctionGraph`.
 
-        The feature has great freedom in what it can do with the
-        function_graph: it may, for example, add methods to it dynamically.
-
-        """
-
-    def on_detach(self, function_graph):
-        """
-        Called by remove_feature(feature).  Should remove any dynamically-added
-        functionality that it installed into the function_graph.
+        The feature has great freedom in what it can do with the `fgraph`: it
+        may, for example, add methods to it dynamically.
 
         """
 
-    def on_import(self, function_graph, node, reason):
+    def on_detach(self, fgraph):
         """
-        Called whenever a node is imported into function_graph, which is
-        just before the node is actually connected to the graph.
-        Note: on_import is not called when the graph is created. If you
-        want to detect the first nodes to be implemented to the graph,
-        you should do this by implementing on_attach.
+        Called by `FunctionGraph.remove_feature`.  Should remove any
+        dynamically-added functionality that it installed into the fgraph.
 
         """
 
-    def on_prune(self, function_graph, node, reason):
+    def on_import(self, fgraph, node, reason):
         """
-        Called whenever a node is pruned (removed) from the function_graph,
-        after it is disconnected from the graph.
+        Called whenever a node is imported into `fgraph`, which is just before
+        the node is actually connected to the graph.
+
+        Note: this is not called when the graph is created. If you want to
+        detect the first nodes to be implemented to the graph, you should do
+        this by implementing `on_attach`.
 
         """
 
-    def on_change_input(self, function_graph, node, i, r, new_r, reason=None):
+    def on_change_input(self, fgraph, node, i, var, new_var, reason=None):
         """
-        Called whenever node.inputs[i] is changed from r to new_r.
-        At the moment the callback is done, the change has already
-        taken place.
+        Called whenever ``node.inputs[i]`` is changed from `var` to `new_var`.
+        At the moment the callback is done, the change has already taken place.
 
         If you raise an exception in this function, the state of the graph
         might be broken for all intents and purposes.
 
         """
 
-    def orderings(self, function_graph):
+    def on_prune(self, fgraph, node, reason):
         """
-        Called by toposort. It should return a dictionary of
-        {node: predecessors} where predecessors is a list of
+        Called whenever a node is pruned (removed) from the `fgraph`, after it
+        is disconnected from the graph.
+
+        """
+
+    def orderings(self, fgraph):
+        """
+        Called by `FunctionGraph.toposort`. It should return a dictionary of
+        ``{node: predecessors}`` where ``predecessors`` is a list of
         nodes that should be computed before the key node.
 
         If you raise an exception in this function, the state of the graph

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -626,7 +626,7 @@ class _make_cdata(Op):
         assert isinstance(rtype, CDataType)
         self.rtype = rtype
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         return False
 
     def make_node(self, val):

--- a/theano/gof/utils.py
+++ b/theano/gof/utils.py
@@ -284,6 +284,78 @@ class D:
         self.__dict__.update(d)
 
 
+class AssocList:
+    """An associative list.
+
+    This class is like a `dict` that accepts unhashable keys by using an
+    assoc list for internal use only
+    """
+
+    def __init__(self):
+        self._dict = {}
+        self._list = []
+
+    def __getitem__(self, item):
+        return self.get(item, None)
+
+    def __setitem__(self, item, value):
+        try:
+            self._dict[item] = value
+        except Exception:
+            for i, (key, val) in enumerate(self._list):
+                if key == item:
+                    self._list[i] = (item, value)
+                    return
+            self._list.append((item, value))
+
+    def __delitem__(self, item):
+        try:
+            if item in self._dict:
+                del self._dict[item]
+                return
+        except TypeError as e:
+            assert "unhashable type" in str(e)
+        for i, (key, val) in enumerate(self._list):
+            if key == item:
+                del self._list[i]
+                return
+            raise KeyError(item)
+
+    def discard(self, item):
+        try:
+            if item in self._dict:
+                del self._dict[item]
+                return
+        except TypeError as e:
+            assert "unhashable type" in str(e)
+        for i, (key, val) in enumerate(self._list):
+            if key == item:
+                del self._list[i]
+                return
+
+    def get(self, item, default):
+        try:
+            return self._dict[item]
+        except Exception:
+            for item2, value in self._list:
+                try:
+                    if item == item2:
+                        return value
+                    if item.equals(item2):
+                        return value
+                except Exception:
+                    if item is item2:
+                        return value
+            return default
+
+    def clear(self):
+        self._dict = {}
+        self._list = []
+
+    def __repr__(self):
+        return f"AssocList({self._dict}, {self._list})"
+
+
 def memoize(f):
     """
     Cache the return value for each tuple of arguments (which must be hashable).

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -135,6 +135,8 @@ class VM:
 
     Parameters
     ----------
+    fgraph : FunctionGraph
+        The `FunctionGraph` associated with `nodes` and `thunks`.
     nodes
         A list of nodes in toposort order.
     thunks
@@ -160,10 +162,11 @@ class VM:
 
     """
 
-    def __init__(self, nodes, thunks, pre_call_clear):
+    def __init__(self, fgraph, nodes, thunks, pre_call_clear):
 
         if len(nodes) != len(thunks):
             raise ValueError()
+        self.fgraph = fgraph
         self.nodes = nodes
         self.thunks = thunks
         self.pre_call_clear = pre_call_clear
@@ -254,7 +257,7 @@ class Loop(VM):
                     self.call_counts[i] += 1
                     self.call_times[i] += t1 - t0
             except Exception:
-                link.raise_with_op(node, thunk)
+                link.raise_with_op(self.fgraph, node, thunk)
         else:
             for cont in self.pre_call_clear:
                 cont[0] = None
@@ -262,7 +265,7 @@ class Loop(VM):
                 for thunk, node in zip(self.thunks, self.nodes):
                     thunk()
             except Exception:
-                link.raise_with_op(node, thunk)
+                link.raise_with_op(self.fgraph, node, thunk)
 
 
 class LoopGC(VM):
@@ -272,8 +275,8 @@ class LoopGC(VM):
 
     """
 
-    def __init__(self, nodes, thunks, pre_call_clear, post_thunk_clear):
-        super().__init__(nodes, thunks, pre_call_clear)
+    def __init__(self, fgraph, nodes, thunks, pre_call_clear, post_thunk_clear):
+        super().__init__(fgraph, nodes, thunks, pre_call_clear)
         self.post_thunk_clear = post_thunk_clear
         # Some other part of Theano query that information
         self.allow_gc = True
@@ -298,7 +301,7 @@ class LoopGC(VM):
                         old_s[0] = None
                     i += 1
             except Exception:
-                link.raise_with_op(node, thunk)
+                link.raise_with_op(self.fgraph, node, thunk)
         else:
             for cont in self.pre_call_clear:
                 cont[0] = None
@@ -310,7 +313,7 @@ class LoopGC(VM):
                     for old_s in old_storage:
                         old_s[0] = None
             except Exception:
-                link.raise_with_op(node, thunk)
+                link.raise_with_op(self.fgraph, node, thunk)
 
 
 class Stack(VM):
@@ -341,19 +344,19 @@ class Stack(VM):
 
     def __init__(
         self,
+        fgraph,
         nodes,
         thunks,
         pre_call_clear,
         storage_map,
         compute_map,
-        fgraph,
         allow_gc,
         n_updates,
         dependencies=None,
         callback=None,
         callback_input=None,
     ):
-        super().__init__(nodes, thunks, pre_call_clear)
+        super().__init__(fgraph, nodes, thunks, pre_call_clear)
 
         self.allow_gc = allow_gc
         self.message = ""
@@ -539,6 +542,7 @@ class Stack(VM):
                                 self.variable_offset[var] = off
                     except Exception:
                         link.raise_with_op(
+                            self.fgraph,
                             current_apply,
                             self.thunks[self.node_idx[current_apply]],
                             storage_map=storage_map,
@@ -610,6 +614,7 @@ class Stack(VM):
 
                 except Exception:
                     link.raise_with_op(
+                        self.fgraph,
                         current_apply,
                         self.thunks[self.node_idx[current_apply]],
                         storage_map=storage_map,
@@ -697,7 +702,8 @@ try:
     from . import lazylinker_c
 
     class CVM(lazylinker_c.CLazyLinker, VM):
-        def __init__(self, *args, **kwargs):
+        def __init__(self, fgraph, *args, **kwargs):
+            self.fgraph = fgraph
             lazylinker_c.CLazyLinker.__init__(self, *args, **kwargs)
             # skip VM.__init__
 
@@ -932,12 +938,12 @@ class VM_Linker(link.LocalLinker):
             # Needed for allow_gc=True, profiling and storage_map reuse
             deps = self.compute_gc_dependencies(storage_map)
             vm = Stack(
+                self.fgraph,
                 nodes,
                 thunks,
                 pre_call_clear,
                 storage_map,
                 compute_map,
-                self.fgraph,
                 self.allow_gc,
                 len(updated_vars),
                 dependencies=deps,
@@ -1037,6 +1043,7 @@ class VM_Linker(link.LocalLinker):
                 c0 = sys.getrefcount(node_n_inputs)
 
             vm = CVM(
+                self.fgraph,
                 nodes,
                 thunks,
                 pre_call_clear,
@@ -1071,6 +1078,7 @@ class VM_Linker(link.LocalLinker):
                 # there is no conditional in the graph
                 if self.allow_gc:
                     vm = LoopGC(
+                        self.fgraph,
                         nodes,
                         thunks,
                         pre_call_clear,
@@ -1078,6 +1086,7 @@ class VM_Linker(link.LocalLinker):
                     )
                 else:
                     vm = Loop(
+                        self.fgraph,
                         nodes,
                         thunks,
                         pre_call_clear,
@@ -1086,12 +1095,12 @@ class VM_Linker(link.LocalLinker):
                 # Needed when allow_gc=True and profiling
                 deps = self.compute_gc_dependencies(storage_map)
                 vm = Stack(
+                    self.fgraph,
                     nodes,
                     thunks,
                     pre_call_clear,
                     storage_map,
                     compute_map,
-                    self.fgraph,
                     self.allow_gc,
                     len(updated_vars),
                     dependencies=deps,

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -895,9 +895,9 @@ class VM_Linker(link.LocalLinker):
             # Fred guess: it could happen for node with multiple outputs when
             # we don't use all outputs.
 
-            if k.owner and k.clients:
+            if k.owner and self.fgraph.clients[k]:
                 ls = []
-                for cl in k.clients:
+                for cl in self.fgraph.clients[k]:
                     if cl[0] != "output":
                         ls += cl[0].outputs
                 dependencies[k] += ls

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -207,11 +207,11 @@ class VM:
         for node, thunk, t, c in zip(
             self.nodes, self.thunks, self.call_times, self.call_counts
         ):
-            profile.apply_time.setdefault(node, 0.0)
-            profile.apply_time[node] += t
+            profile.apply_time.setdefault((self.fgraph, node), 0.0)
+            profile.apply_time[(self.fgraph, node)] += t
 
-            profile.apply_callcount.setdefault(node, 0)
-            profile.apply_callcount[node] += c
+            profile.apply_callcount.setdefault((self.fgraph, node), 0)
+            profile.apply_callcount[(self.fgraph, node)] += c
 
             profile.apply_cimpl[node] = hasattr(thunk, "cthunk")
 

--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -992,7 +992,7 @@ class GpuAlloc(HideC, Alloc):
     def c_code_cache_version(self):
         return (4,)
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         from . import blas, subtensor
 
         for client in node.outputs[0].clients:
@@ -1117,7 +1117,7 @@ if (theano_prep_output(&%(zz)s, %(ndim)s, shape, %(params)s->typecode, GA_C_ORDE
     def c_code_cache_version(self):
         return (2,)
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         return False
 
     def infer_shape(self, node, input_shapes):

--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -995,7 +995,7 @@ class GpuAlloc(HideC, Alloc):
     def do_constant_folding(self, fgraph, node):
         from . import blas, subtensor
 
-        for client in node.outputs[0].clients:
+        for client in fgraph.clients[node.outputs[0]]:
             if client[0] == "output":
                 # If the output is a constant, it will have to be deepcopied
                 # each time the function is called.  So we do not fold.

--- a/theano/gpuarray/basic_ops.py
+++ b/theano/gpuarray/basic_ops.py
@@ -672,7 +672,7 @@ class HostFromGpu(Op):
         (ev,) = eval_points
         return [self(ev)]
 
-    def infer_shape(self, node, xshp):
+    def infer_shape(self, fgraph, node, xshp):
         return xshp
 
 
@@ -729,7 +729,7 @@ class GpuFromHost(Op):
         (ev,) = eval_points
         return [self(ev)]
 
-    def infer_shape(self, node, xshp):
+    def infer_shape(self, fgraph, node, xshp):
         return xshp
 
     def c_headers(self):
@@ -828,7 +828,7 @@ class GpuToGpu(Op):
     def R_op(self, inputs, eval_points):
         return self(eval_points[0])
 
-    def infer_shape(self, node, xshp):
+    def infer_shape(self, fgraph, node, xshp):
         return xshp
 
     def c_code(self, node, name, inputs, outputs, sub):
@@ -1120,7 +1120,7 @@ if (theano_prep_output(&%(zz)s, %(ndim)s, shape, %(params)s->typecode, GA_C_ORDE
     def do_constant_folding(self, fgraph, node):
         return False
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [node.inputs]
 
     def grad(self, *args):
@@ -1664,20 +1664,23 @@ def profile_printer(
     message, compile_time, fct_call_time, apply_time, apply_cimpl, outputs_size, file
 ):
     if any(
-        [x.op.__class__.__name__.lower().startswith("gpu") for x in apply_time.keys()]
+        [
+            x.op.__class__.__name__.lower().startswith("gpu")
+            for (fgraph, x) in apply_time.keys()
+        ]
     ):
         local_time = sum(apply_time.values())
         print("", file=file)
         print("Some info useful for gpu:", file=file)
 
         fgraphs = set()
-        for node in apply_time.keys():
-            fgraphs.add(node.fgraph)
+        for fgraph, node in apply_time.keys():
+            fgraphs.add(fgraph)
 
         cpu = 0
         gpu = 0
         trans = 0
-        for node, t in apply_time.items():
+        for (fgraph, node), t in apply_time.items():
             if isinstance(node.op, (HostFromGpu, GpuFromHost)):
                 trans += t
             elif node.op.__class__.__name__.lower().startswith("gpu"):
@@ -1773,7 +1776,7 @@ class GpuEye(GpuKernelBase, Op):
 
         return Apply(self, [n, m, k], [otype()])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         out_shape = [node.inputs[0], node.inputs[1]]
         return [out_shape]
 
@@ -1907,7 +1910,7 @@ class GpuTri(GpuKernelBase, Op):
 
         return Apply(self, [n, m, k], [otype()])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         out_shape = [node.inputs[0], node.inputs[1]]
         return [out_shape]
 

--- a/theano/gpuarray/blocksparse.py
+++ b/theano/gpuarray/blocksparse.py
@@ -66,7 +66,7 @@ class GpuSparseBlockGemv(COp):
 
         return Apply(self, [o, W, h, inputIdx, outputIdx], [o.type()])
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]
 
     def grad(self, inputs, grads):
@@ -124,7 +124,7 @@ class GpuSparseBlockOuter(COp):
             alpha = one
         return Apply(self, [o, x, y, xIdx, yIdx, alpha], [o.type()])
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]
 
     def c_header_dirs(self):

--- a/theano/gpuarray/ctc.py
+++ b/theano/gpuarray/ctc.py
@@ -211,7 +211,7 @@ def gpu_ctc(activations, labels, input_lengths):
 # Disable gradient computation if not needed
 @register_canonicalize("fast_compile")
 @local_optimizer([GpuConnectionistTemporalClassification])
-def local_gpu_ctc_no_grad(node):
+def local_gpu_ctc_no_grad(fgraph, node):
     if isinstance(node.op, GpuConnectionistTemporalClassification):
         if len(node.outputs) > 1:
             if len(node.outputs[1].clients) == 0:  # gradient is not used

--- a/theano/gpuarray/ctc.py
+++ b/theano/gpuarray/ctc.py
@@ -214,7 +214,7 @@ def gpu_ctc(activations, labels, input_lengths):
 def local_gpu_ctc_no_grad(fgraph, node):
     if isinstance(node.op, GpuConnectionistTemporalClassification):
         if len(node.outputs) > 1:
-            if len(node.outputs[1].clients) == 0:  # gradient is not used
+            if len(fgraph.clients[node.outputs[1]]) == 0:  # gradient is not used
                 return [
                     GpuConnectionistTemporalClassification(compute_grad=False)(
                         *node.inputs

--- a/theano/gpuarray/dnn.py
+++ b/theano/gpuarray/dnn.py
@@ -802,7 +802,7 @@ class GpuDnnConv(DnnBase):
 
         return get_conv_output_shape(ishape, kshape, border_mode, subsample, dilation)
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[2]]
 
 
@@ -973,7 +973,7 @@ class GpuDnnConvGradW(DnnBase):
 
         return Apply(self, [img, topgrad, output, desc, alpha, beta], [output.type()])
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[2]]
 
 
@@ -1109,7 +1109,7 @@ class GpuDnnConvGradI(DnnBase):
 
         return Apply(self, [kern, topgrad, output, desc, alpha, beta], [output.type()])
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[2]]
 
 
@@ -1876,7 +1876,7 @@ class GpuDnnPool(GpuDnnPoolBase):
 
         return Apply(self, [img, ws, stride, pad], [img.type()])
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         w = node.inputs[1]
         s = node.inputs[2]
         p = node.inputs[3]
@@ -1960,7 +1960,7 @@ class GpuDnnPoolGrad(GpuDnnPoolBase):
 
         return Apply(self, [inp, out, out_grad, ws, stride, pad], [inp.type()])
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[0]]
 
 
@@ -2046,7 +2046,7 @@ class GpuDnnSoftmaxBase(DnnBase):
         assert cudnn.cudnnSoftmaxMode_t.has_alias(mode)
         self.mode = mode
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         if self.direction == "forward":
             return [shape[0]]
         else:
@@ -2288,7 +2288,7 @@ class GpuDnnBatchNorm(DnnBase):
             self.inplace_output = False
             self.destroy_map = {}
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[0]] + [shape[1]] * (len(node.outputs) - 1)
 
     def make_node(
@@ -2401,7 +2401,7 @@ class GpuDnnBatchNormInference(DnnBase):
         if not hasattr(self, "inplace"):
             self.inplace = False
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[0]]
 
     def make_node(
@@ -2495,7 +2495,7 @@ class GpuDnnBatchNormGrad(DnnBase):
             [x.type(), scale.type(), scale.type()],
         )
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[0], shape[2], shape[2]]
 
 

--- a/theano/gpuarray/dnn_opt.py
+++ b/theano/gpuarray/dnn_opt.py
@@ -1,7 +1,7 @@
 import theano
 from theano.compile import optdb
 from theano.compile.ops import shape_i_op
-from theano.gof.opt import Optimizer, inherit_stack_trace, local_optimizer
+from theano.gof.opt import GlobalOptimizer, inherit_stack_trace, local_optimizer
 from theano.gpuarray.basic_ops import (
     GpuAllocEmpty,
     GpuArrayType,
@@ -817,7 +817,7 @@ def local_dnn_argmax(op, ctx_name, inputs, outputs):
     return [as_gpuarray_variable(arg.astype("int64"), ctx_name)]
 
 
-class NoCuDNNRaise(Optimizer):
+class NoCuDNNRaise(GlobalOptimizer):
     def apply(self, fgraph):
         """
         Raise a error if cudnn can't be used.

--- a/theano/gpuarray/dnn_opt.py
+++ b/theano/gpuarray/dnn_opt.py
@@ -639,7 +639,7 @@ def local_log_softmax_dnn(fgraph, node):
         and isinstance(node.op.scalar_op, Log)
         and node.inputs[0].owner
         and isinstance(node.inputs[0].owner.op, GpuDnnSoftmax)
-        and len(node.inputs[0].clients) == 1
+        and len(fgraph.clients[node.inputs[0]]) == 1
     ):
         softmax_node = node.inputs[0].owner
         new_softmax = GpuDnnSoftmax("log", softmax_node.op.mode)

--- a/theano/gpuarray/linalg.py
+++ b/theano/gpuarray/linalg.py
@@ -801,7 +801,7 @@ class GpuMagmaSVD(GpuMagmaBase):
     def get_params(self, node):
         return self.params_type.get_params(self, context=node.inputs[0].type.context)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         (x_shape,) = shapes
         M, N = x_shape
         K = tensor.minimum(M, N)
@@ -870,7 +870,7 @@ class GpuMagmaMatrixInverse(GpuMagmaBase):
     def get_params(self, node):
         return self.params_type.get_params(self, context=node.inputs[0].type.context)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return shapes
 
 
@@ -921,7 +921,7 @@ class GpuMagmaCholesky(GpuMagmaBase, CGpuKernelBase):
     def get_params(self, node):
         return self.params_type.get_params(self, context=node.inputs[0].type.context)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 

--- a/theano/gpuarray/nnet.py
+++ b/theano/gpuarray/nnet.py
@@ -520,7 +520,7 @@ class GpuSoftmax(GpuKernelBase, Op):
         x = as_gpuarray_variable(x, infer_context_name(x))
         return Apply(self, [x], [x.type()])
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return shape
 
     def c_code_cache_version(self):
@@ -820,7 +820,7 @@ class GpuSoftmaxWithBias(GpuKernelBase, Op):
         b = as_gpuarray_variable(b, ctx_name)
         return Apply(self, [x, b], [x.type()])
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[0]]
 
     def c_code_cache_version(self):

--- a/theano/gpuarray/opt.py
+++ b/theano/gpuarray/opt.py
@@ -15,7 +15,7 @@ from theano import config, gof, scalar, tensor
 from theano.breakpoint import PdbBreakpoint
 from theano.compile import optdb
 from theano.compile.ops import shape_i
-from theano.gof import Optimizer, graph, local_optimizer, toolbox
+from theano.gof import GlobalOptimizer, graph, local_optimizer, toolbox
 from theano.gof.opt import LocalMetaOptimizer, copy_stack_trace, inherit_stack_trace
 from theano.gpuarray.basic_ops import (
     GpuAlloc,
@@ -210,7 +210,7 @@ gpu_neg = GpuElemwise(neg)
 gpu_true_div = GpuElemwise(true_div)
 
 
-class InputToGpuOptimizer(Optimizer):
+class InputToGpuOptimizer(GlobalOptimizer):
     """
     Transfer the input to the gpu to start the rolling wave.
 
@@ -260,7 +260,7 @@ gpu_seqopt.register(
 )
 
 
-class GraphToGPU(Optimizer):
+class GraphToGPU(GlobalOptimizer):
     """
     Transfer the graph as a whole to GPU instead of transferring node by node.
 

--- a/theano/gpuarray/opt_util.py
+++ b/theano/gpuarray/opt_util.py
@@ -68,7 +68,7 @@ def grab_cpu_scalar(v, nd):
             return v.dimshuffle(())
 
 
-def find_node(v, cls, ignore_clients=False):
+def find_node(fgraph, v, cls, ignore_clients=False):
     """
     Find the node that has an op of of type `cls` in `v`.
 
@@ -96,7 +96,7 @@ def find_node(v, cls, ignore_clients=False):
             and (ignore_clients or len(v.owner.inputs[0].clients) == 1)
             and isinstance(v.owner.inputs[0].owner.op, HostFromGpu)
         ):
-            return find_node(v.owner.inputs[0].owner.inputs[0], cls)
+            return find_node(fgraph, v.owner.inputs[0].owner.inputs[0], cls)
         else:
             return None
 
@@ -179,15 +179,15 @@ def alpha_merge(cls, alpha_in, beta_in):
     def wrapper(maker):
         @local_optimizer([GpuElemwise])
         @wraps(maker)
-        def opt(node):
+        def opt(fgraph, node):
             if (
                 isinstance(node.op, GpuElemwise)
                 and node.op.scalar_op == scal.mul
                 and node.nin == 2
             ):
-                targ = find_node(node.inputs[0], cls)
+                targ = find_node(fgraph, node.inputs[0], cls)
                 if targ is None:
-                    targ = find_node(node.inputs[1], cls)
+                    targ = find_node(fgraph, node.inputs[1], cls)
                     if targ is None:
                         return
                     lr = grab_cpu_scalar(node.inputs[0], nd=targ.outputs[0].ndim)
@@ -279,16 +279,16 @@ def output_merge(cls, alpha_in, beta_in, out_in):
     def wrapper(maker):
         @local_optimizer([GpuElemwise])
         @wraps(maker)
-        def opt(node):
+        def opt(fgraph, node):
             if (
                 isinstance(node.op, GpuElemwise)
                 and node.op.scalar_op == scal.add
                 and node.nin == 2
             ):
-                targ = find_node(node.inputs[0], cls)
+                targ = find_node(fgraph, node.inputs[0], cls)
                 W = node.inputs[1]
                 if targ is None:
-                    targ = find_node(node.inputs[1], cls)
+                    targ = find_node(fgraph, node.inputs[1], cls)
                     W = node.inputs[0]
                 if targ is None:
                     return None
@@ -354,7 +354,7 @@ def inplace_allocempty(op, idx):
     def wrapper(maker):
         @local_optimizer([op], inplace=True)
         @wraps(maker)
-        def opt(node):
+        def opt(fgraph, node):
             if type(node.op) != op or node.op.inplace:
                 return
             inputs = list(node.inputs)
@@ -456,7 +456,7 @@ def op_lifter(OP, cuda_only=False):
     """
 
     def f(maker):
-        def local_opt(node):
+        def local_opt(fgraph, node):
             if type(node.op) in OP:
                 # Either one of our inputs is on the gpu or
                 # all of our clients are on the gpu

--- a/theano/gpuarray/pool.py
+++ b/theano/gpuarray/pool.py
@@ -86,7 +86,7 @@ class GpuPool(CGpuKernelBase):
 
         return Apply(self, [inp, ws, stride, pad], [inp.type()])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         ws, stride, pad = [node.inputs[1], node.inputs[2], node.inputs[3]]
         shp = Pool.out_shape(
             in_shapes[0], ws, self.ignore_border, stride, pad, self.ndim
@@ -195,7 +195,7 @@ class GpuMaxPoolGrad(CGpuKernelBase):
 
         return Apply(self, [inp, out, out_grad, ws, stride, pad], [inp.type()])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         return [in_shapes[0]]
 
     def grad(self, inp, grads):
@@ -278,7 +278,7 @@ class GpuAveragePoolGrad(CGpuKernelBase):
 
         return Apply(self, [inp, out_grad, ws, stride, pad], [inp.type()])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         return [in_shapes[0]]
 
     def grad(self, inp, grads):
@@ -354,7 +354,7 @@ class GpuDownsampleFactorMaxGradGrad(CGpuKernelBase):
 
         return Apply(self, [inp, out, out_grad, ws, stride, pad], [inp.type()])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         return [in_shapes[1]]
 
     def grad(self, inp, grads):
@@ -437,7 +437,7 @@ class GpuMaxPoolRop(CGpuKernelBase):
 
         return Apply(self, [inp, eval_point, ws, stride, pad], [eval_point.type()])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         ws, stride, pad = [node.inputs[2], node.inputs[3], node.inputs[4]]
         shp = Pool.out_shape(
             in_shapes[0], ws, self.ignore_border, stride, pad, self.ndim

--- a/theano/gpuarray/rng_mrg.py
+++ b/theano/gpuarray/rng_mrg.py
@@ -329,7 +329,7 @@ class GPUA_mrg_uniform(GpuKernelBase, mrg_uniform_base):
 
 
 @register_opt2([mrg_uniform], "fast_compile")
-def local_gpua_mrg_graph(op, context_name, inputs, outputs):
+def local_gpua_mrg_graph(fgraph, op, context_name, inputs, outputs):
     if (
         type(op) == mrg_uniform
         and isinstance(inputs[0].type, GpuArrayType)
@@ -343,6 +343,8 @@ def local_gpua_mrg_graph(op, context_name, inputs, outputs):
 
 @register_opt("fast_compile")
 @local_optimizer([mrg_uniform])
-def local_gpua_mrg(node):
+def local_gpua_mrg(fgraph, node):
     context_name = infer_context_name(*node.inputs)
-    return local_gpua_mrg_graph(node.op, context_name, node.inputs, node.outputs)
+    return local_gpua_mrg_graph(
+        fgraph, node.op, context_name, node.inputs, node.outputs
+    )

--- a/theano/gpuarray/subtensor.py
+++ b/theano/gpuarray/subtensor.py
@@ -1429,7 +1429,7 @@ class GpuExtractDiag(Op):
         (input_x,) = inputs
         return [grad_not_implemented(self, 0, input_x)]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         (in_shape,) = shapes
         dim1 = in_shape[self.axis1]
         dim2 = in_shape[self.axis2]

--- a/theano/ifelse.py
+++ b/theano/ifelse.py
@@ -415,7 +415,7 @@ def ifelse(condition, then_branch, else_branch, name=None):
 
 
 @gof.local_optimizer([IfElse])
-def cond_make_inplace(node):
+def cond_make_inplace(fgraph, node):
     op = node.op
     if (
         isinstance(op, IfElse)
@@ -424,7 +424,7 @@ def cond_make_inplace(node):
         # For big graph, do not make inplace scalar to speed up
         # optimization.
         (
-            len(node.fgraph.apply_nodes) < 500
+            len(fgraph.apply_nodes) < 500
             or not all([getattr(o.type, "ndim", -1) == 0 for o in node.outputs])
         )
     ):
@@ -492,7 +492,7 @@ acceptable_ops = (
 
 
 @gof.local_optimizer(acceptable_ops)
-def ifelse_lift_single_if_through_acceptable_ops(main_node):
+def ifelse_lift_single_if_through_acceptable_ops(fgraph, main_node):
     """This optimization lifts up certain ifelse instances.
 
         op(ifelse(c, x, y)) -> ifelse(c, op(x), op(y))
@@ -539,7 +539,7 @@ def ifelse_lift_single_if_through_acceptable_ops(main_node):
 
 
 @gof.local_optimizer([IfElse])
-def cond_merge_ifs_true(node):
+def cond_merge_ifs_true(fgraph, node):
     op = node.op
     if not isinstance(op, IfElse):
         return False
@@ -566,7 +566,7 @@ def cond_merge_ifs_true(node):
 
 
 @gof.local_optimizer([IfElse])
-def cond_merge_ifs_false(node):
+def cond_merge_ifs_false(fgraph, node):
     op = node.op
     if not isinstance(op, IfElse):
         return False
@@ -645,7 +645,7 @@ class CondMerge(gof.GlobalOptimizer):
 
 
 @gof.local_optimizer([IfElse])
-def cond_remove_identical(node):
+def cond_remove_identical(fgraph, node):
     op = node.op
 
     if not isinstance(op, IfElse):
@@ -691,7 +691,7 @@ def cond_remove_identical(node):
 
 
 @gof.local_optimizer([IfElse])
-def cond_merge_random_op(main_node):
+def cond_merge_random_op(fgraph, main_node):
     if isinstance(main_node.op, IfElse):
         return False
 

--- a/theano/ifelse.py
+++ b/theano/ifelse.py
@@ -100,7 +100,7 @@ class IfElse(Op):
             args.append("gpu")
         return "if{{{','.join(args)}}}"
 
-    def infer_shape(self, node, inputs_shapes):
+    def infer_shape(self, fgraph, node, inputs_shapes):
         # By construction, corresponding then/else pairs have the same number
         # of dimensions
 

--- a/theano/ifelse.py
+++ b/theano/ifelse.py
@@ -592,7 +592,7 @@ def cond_merge_ifs_false(node):
     return op(*old_ins, **dict(return_list=True))
 
 
-class CondMerge(gof.Optimizer):
+class CondMerge(gof.GlobalOptimizer):
     """ Graph Optimizer that merges different cond ops """
 
     def add_requirements(self, fgraph):

--- a/theano/misc/doubleop.py
+++ b/theano/misc/doubleop.py
@@ -50,7 +50,7 @@ class DoubleOp(theano.Op):
         z = output_storage[0]
         z[0] = x * 2
 
-    def infer_shape(self, node, i0_shapes):
+    def infer_shape(self, fgraph, node, i0_shapes):
         return i0_shapes
 
     def grad(self, inputs, output_grads):

--- a/theano/sandbox/linalg/ops.py
+++ b/theano/sandbox/linalg/ops.py
@@ -3,7 +3,7 @@ import logging
 import theano.tensor
 from theano import tensor
 from theano.gof import Apply, Op, local_optimizer
-from theano.gof.opt import Optimizer
+from theano.gof.opt import GlobalOptimizer
 from theano.tensor import DimShuffle, Dot
 from theano.tensor.blas import Dot22
 from theano.tensor.nlinalg import (
@@ -171,13 +171,13 @@ class HintsFeature:
         # 2) we are putting things back after a failed transaction.
 
 
-class HintsOptimizer(Optimizer):
+class HintsOptimizer(GlobalOptimizer):
     """
     Optimizer that serves to add HintsFeature as an fgraph feature.
     """
 
     def __init__(self):
-        Optimizer.__init__(self)
+        super().__init__()
 
     def add_requirements(self, fgraph):
         fgraph.attach_feature(HintsFeature())

--- a/theano/sandbox/linalg/ops.py
+++ b/theano/sandbox/linalg/ops.py
@@ -322,7 +322,7 @@ def local_det_chol(fgraph, node):
     """
     if node.op == det:
         (x,) = node.inputs
-        for (cl, xpos) in x.clients:
+        for (cl, xpos) in fgraph.clients[x]:
             if isinstance(cl.op, Cholesky):
                 L = cl.outputs[0]
                 return [tensor.prod(extract_diag(L) ** 2)]

--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -1344,7 +1344,7 @@ def _check_size(size):
 
 
 @local_optimizer((mrg_uniform_base,))
-def mrg_random_make_inplace(node):
+def mrg_random_make_inplace(fgraph, node):
 
     op = node.op
     if isinstance(op, mrg_uniform_base) and not op.inplace:

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -4173,7 +4173,7 @@ class Composite(ScalarOp):
                 r.name = f"o{int(i)}"
             io = set(self.fgraph.inputs + self.fgraph.outputs)
             for i, r in enumerate(self.fgraph.variables):
-                if r not in io and len(r.clients) > 1:
+                if r not in io and len(self.fgraph.clients[r]) > 1:
                     r.name = f"t{int(i)}"
             outputs_str = ", ".join([pprint(output) for output in self.fgraph.outputs])
             rval = f"Composite{{{outputs_str}}}"

--- a/theano/scan/op.py
+++ b/theano/scan/op.py
@@ -1719,7 +1719,7 @@ class Scan(PureOp):
         self.t_fn = t_fn
 
     # Infer Shape
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         # input_shapes correspond to the shapes of node.inputs
         for inp, inp_shp in zip(node.inputs, input_shapes):
             assert inp_shp is None or len(inp_shp) == inp.type.ndim
@@ -3053,7 +3053,12 @@ def profile_printer(
     message, compile_time, fct_call_time, apply_time, apply_cimpl, outputs_size, file
 ):
     # Scan overhead profile
-    if any([isinstance(node.op, Scan) and v > 0 for node, v in apply_time.items()]):
+    if any(
+        [
+            isinstance(node.op, Scan) and v > 0
+            for (fgraph, node), v in apply_time.items()
+        ]
+    ):
         print("", file=file)
         print("Scan overhead:", file=file)
         print(
@@ -3066,7 +3071,7 @@ def profile_printer(
         total_super_scan_time = 0
         total_scan_fct_time = 0
         total_scan_op_time = 0
-        for node, v in apply_time.items():
+        for (fgraph, node), v in apply_time.items():
             if isinstance(node.op, Scan) and not node.op.fn.profile:
                 print(
                     "  One scan node do not have its inner profile enabled. "

--- a/theano/scan/op.py
+++ b/theano/scan/op.py
@@ -1466,6 +1466,7 @@ class Scan(PureOp):
                     if hasattr(fn, "thunks"):
                         # For the CVM
                         gof.link.raise_with_op(
+                            self.fn.maker.fgraph,
                             fn.nodes[fn.position_of_error],
                             fn.thunks[fn.position_of_error],
                         )
@@ -1474,7 +1475,9 @@ class Scan(PureOp):
                         # We don't have access from python to all the
                         # temps values So for now, we just don't print
                         # the extra shapes/strides info
-                        gof.vm.raise_with_op(fn.nodes[fn.position_of_error])
+                        gof.link.raise_with_op(
+                            self.fn.maker.fgraph, fn.nodes[fn.position_of_error]
+                        )
                 else:
                     # old-style linkers raise their own exceptions
                     raise

--- a/theano/scan/opt.py
+++ b/theano/scan/opt.py
@@ -1126,7 +1126,7 @@ class ScanInplaceOptimizer(GlobalOptimizer):
 
 class ScanSaveMem(gof.GlobalOptimizer):
     """
-    Graph Optimizer that reduces scan memory consumption.
+    Graph optimizer that reduces scan memory consumption.
 
     """
 
@@ -1160,7 +1160,7 @@ class ScanSaveMem(gof.GlobalOptimizer):
                 return tensor.as_tensor_variable(x)
 
         if hasattr(fgraph, "shape_feature"):
-            shape_of = node.fgraph.shape_feature.shape_of
+            shape_of = fgraph.shape_feature.shape_of
         else:
             # Each access to shape_of is in a try..except block in order to
             # use a default version when the variable is not in the shape_of
@@ -1671,7 +1671,7 @@ class ScanSaveMem(gof.GlobalOptimizer):
 
 class ScanMerge(gof.GlobalOptimizer):
     """
-    Graph Optimizer that merges different scan ops.
+    Graph optimizer that merges different scan ops.
 
     """
 

--- a/theano/scan/opt.py
+++ b/theano/scan/opt.py
@@ -63,7 +63,11 @@ from theano.compile import optdb
 from theano.compile.function.types import deep_copy_op
 from theano.gof import DestroyHandler, InconsistencyError, toolbox
 from theano.gof.graph import equal_computations
-from theano.gof.opt import Optimizer, pre_constant_merge, pre_greedy_local_optimizer
+from theano.gof.opt import (
+    GlobalOptimizer,
+    pre_constant_merge,
+    pre_greedy_local_optimizer,
+)
 from theano.scan.op import Scan
 from theano.scan.utils import (
     clone,
@@ -224,14 +228,14 @@ def remove_constants_and_unused_inputs_scan(node):
 
 # This is a global opt for historical reason
 # It should be possible to change it to a local opt.
-class PushOutNonSeqScan(gof.Optimizer):
+class PushOutNonSeqScan(gof.GlobalOptimizer):
     """
     A global optimizer for pushing out the variables inside the scan that depend
     only on non-sequences.
     """
 
     def __init__(self):
-        gof.Optimizer.__init__(self)
+        super().__init__()
 
     def add_requirements(self, fgraph):
         fgraph.attach_feature(gof.toolbox.ReplaceValidate())
@@ -440,14 +444,14 @@ class PushOutNonSeqScan(gof.Optimizer):
 
 # This is a global opt for historical reason
 # It should be possible to change it to a local opt.
-class PushOutSeqScan(gof.Optimizer):
+class PushOutSeqScan(gof.GlobalOptimizer):
     """
     A global optimizer for pushing out the variables inside the
     scan that depend only on constants and sequences.
     """
 
     def __init__(self):
-        gof.Optimizer.__init__(self)
+        super().__init__()
 
     def add_requirements(self, fgraph):
         fgraph.attach_feature(gof.toolbox.ReplaceValidate())
@@ -696,14 +700,14 @@ class PushOutSeqScan(gof.Optimizer):
             return False
 
 
-class PushOutScanOutput(gof.Optimizer):
+class PushOutScanOutput(gof.GlobalOptimizer):
     """
     This is an optimization that can push operations performed
     at the end of the inner graph of scan to outside of scan.
     """
 
     def __init__(self):
-        gof.Optimizer.__init__(self)
+        super().__init__()
 
     def add_requirements(self, fgraph):
         fgraph.attach_feature(gof.toolbox.ReplaceValidate())
@@ -958,14 +962,14 @@ class PushOutScanOutput(gof.Optimizer):
         return new_scan_node
 
 
-class ScanInplaceOptimizer(Optimizer):
+class ScanInplaceOptimizer(GlobalOptimizer):
     """
     Graph optimizer for Scan (makes it run inplace).
 
     """
 
     def __init__(self, typeInfer=None, gpua_flag=False):
-        Optimizer.__init__(self)
+        super().__init__()
         self.typeInfer = typeInfer
         self.gpua_flag = gpua_flag
 
@@ -1124,14 +1128,14 @@ class ScanInplaceOptimizer(Optimizer):
                     node = self.attempt_scan_inplace(fgraph, node, [pos], alloc_ops)
 
 
-class ScanSaveMem(gof.Optimizer):
+class ScanSaveMem(gof.GlobalOptimizer):
     """
     Graph Optimizer that reduces scan memory consumption.
 
     """
 
     def __init__(self):
-        gof.Optimizer.__init__(self)
+        super().__init__()
 
     def add_requirements(self, fgraph):
         fgraph.attach_feature(gof.toolbox.ReplaceValidate())
@@ -1680,7 +1684,7 @@ class ScanSaveMem(gof.Optimizer):
             self.process_node(fgraph, node)
 
 
-class ScanMerge(gof.Optimizer):
+class ScanMerge(gof.GlobalOptimizer):
     """
     Graph Optimizer that merges different scan ops.
 
@@ -2135,14 +2139,14 @@ def scan_merge_inouts(node):
     return na.outer_outputs
 
 
-class PushOutDot1(gof.Optimizer):
+class PushOutDot1(gof.GlobalOptimizer):
     """
     Graph optimizer for Scan(makes it run inplace).
 
     """
 
     def __init__(self):
-        Optimizer.__init__(self)
+        super().__init__()
 
     def add_requirements(self, fgraph):
         fgraph.attach_feature(toolbox.ReplaceValidate())

--- a/theano/scan/utils.py
+++ b/theano/scan/utils.py
@@ -311,7 +311,7 @@ def map_variables(replacer, graphs, additional_inputs=None):
     nodes_seen = set()
 
     @gof.opt.local_optimizer(None)
-    def local_transform(node):
+    def local_transform(fgraph, node):
         if node in nodes_seen:
             return False
 

--- a/theano/scan/utils.py
+++ b/theano/scan/utils.py
@@ -286,7 +286,7 @@ def map_variables(replacer, graphs, additional_inputs=None):
     # perform any desired replacement of input variables.  these
     # aren't replaced by the local optimizer approach because they are
     # not outputs of any Apply node.
-    new_inputs = list(map(wrapped_replacer, inputs_))
+    new_inputs = [wrapped_replacer(i) for i in inputs_]
     replacements = [
         (input_, new_input)
         for input_, new_input in zip(inputs_, new_inputs)
@@ -294,17 +294,6 @@ def map_variables(replacer, graphs, additional_inputs=None):
     ]
     graphs = clone(graphs, share_inputs=True, replace=replacements)
     inputs_ = list(set(gof.graph.inputs(graphs) + list(additional_inputs)))
-
-    # clone cached constants or FunctionGraph will complain.  this has
-    # to occur in a separate pass from the replacement above because
-    # both may suggest different replacements for the same variables.
-    # since the replacements introduced above may involve cached
-    # constants, the replacement of said constants has to come after.
-    cached_constants = [x for x in inputs_ if getattr(x, "cached", False)]
-    copied_constants = clone(cached_constants, share_inputs=False)
-    replacements = list(zip(cached_constants, copied_constants))
-    inputs_ = list(set(inputs_) - set(cached_constants)) + list(copied_constants)
-    graphs = clone(graphs, share_inputs=True, replace=replacements)
 
     fg = gof.fg.FunctionGraph(inputs_, graphs, clone=False)
 
@@ -351,7 +340,13 @@ def map_variables(replacer, graphs, additional_inputs=None):
             return new_node.outputs
         else:
             nodes_seen.add(node)
-            return list(map(wrapped_replacer, node.outputs))
+            replacements = [wrapped_replacer(o) for o in node.outputs]
+
+            # Add inputs to replacement graphs as inputs to this `fgraph`
+            for i in gof.graph.inputs(replacements):
+                fgraph.add_input(i)
+
+            return replacements
 
     topo_transform = gof.opt.TopoOptimizer(local_transform, "out_to_in")
     topo_transform.optimize(fg)
@@ -436,10 +431,6 @@ def _map_variables_inner(
                 outer_to_inner[outer_input] = inner_input
                 extra_inner_inputs.append(inner_input)
                 extra_outer_inputs.append(outer_input)
-                # the inner FunctionGraph wants to know its inputs
-                # beforehand, but we don't always know.  so add them
-                # as we discover them.
-                graph.owner.fgraph.add_input(inner_input)
 
         replacements.extend(outer_to_inner.items())
 
@@ -684,19 +675,7 @@ class Validator:
 
             if out.owner is None:
                 if isinstance(out, tensor.TensorConstant):
-                    if hasattr(out, "fgraph") or getattr(out, "cached", False):
-                        # If out have an fgraph, we aren't sure if it
-                        # is from the inner graph or outer graph, so
-                        # clone it.
-                        # As it will be used as is in an FunctionGraph
-                        # (won't be cloned later), it can't be a
-                        # cached variable
-                        cloned_out = out.clone()
-                        self.valid.add(cloned_out)
-                        self.invalid.add(out)
-                        self.valid_equivalent[out] = cloned_out
-                    else:
-                        self.valid.add(out)
+                    self.valid.add(out)
                     continue
                 else:
                     # This is an input node and it has not been

--- a/theano/sparse/basic.py
+++ b/theano/sparse/basic.py
@@ -653,7 +653,7 @@ class CSM(gof.Op):
             DisconnectedType()(),
         ]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         # node.inputs[3] is of length as we only support sparse matrix.
         return [(node.inputs[3][0], node.inputs[3][1])]
 
@@ -794,7 +794,7 @@ class CSMGrad(gof.op.Op):
 
         g_out[0] = gout_data
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[1]]
 
 
@@ -840,7 +840,7 @@ class Cast(gof.op.Op):
             else:
                 return [Cast(inputs[0].dtype)(gz)]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return ins_shapes
 
     def __str__(self):
@@ -936,7 +936,7 @@ class DenseFromSparse(gof.op.Op):
         else:
             return [SparseFromDense(x.type.format)(gz)]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -1003,7 +1003,7 @@ class SparseFromDense(gof.op.Op):
         gx = tensor.patternbroadcast(gx, x.broadcastable)
         return (gx,)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -1045,7 +1045,7 @@ class GetItemList(gof.op.Op):
 
     __props__ = ()
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [(shapes[1][0], shapes[0][1])]
 
     def make_node(self, x, index):
@@ -1097,7 +1097,7 @@ class GetItemListGrad(gof.op.Op):
 
     __props__ = ()
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [(shapes[0])]
 
     def make_node(self, x, index, gz):
@@ -1198,7 +1198,7 @@ class GetItem2ListsGrad(gof.op.Op):
 
     __props__ = ()
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [(shapes[0])]
 
     def make_node(self, x, ind1, ind2, gz):
@@ -1243,7 +1243,7 @@ class GetItem2d(gof.op.Op):
 
     # Fred:Too complicated for now. If you need it, look at
     # the Subtensor.infer_shape.
-    #    def infer_shape(self, node, i0_shapes):
+    #    def infer_shape(self, fgraph, node, i0_shapes):
     #        return i0_shapes
     def make_node(self, x, index):
         scipy_ver = [int(n) for n in scipy.__version__.split(".")[:2]]
@@ -1379,7 +1379,7 @@ class GetItemScalar(gof.op.Op):
     # See doc in instance of this Op or function after this class definition.
     __props__ = ()
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [()]
 
     def make_node(self, x, index):
@@ -1473,7 +1473,7 @@ class Transpose(gof.op.Op):
         assert _is_sparse_variable(x) and _is_sparse_variable(gz)
         return (transpose(gz),)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0][::-1]]
 
 
@@ -1526,7 +1526,7 @@ class Neg(gof.op.Op):
         assert _is_sparse_variable(x) and _is_sparse_variable(gz)
         return (-gz,)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -1591,7 +1591,7 @@ class ColScaleCSC(gof.op.Op):
         (gz,) = gout
         return [col_scale(gz, s), sp_sum(x * gz, axis=0)]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[0]]
 
 
@@ -1640,7 +1640,7 @@ class RowScaleCSC(gof.op.Op):
         (gz,) = gout
         return [row_scale(gz, s), sp_sum(x * gz, axis=1)]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[0]]
 
 
@@ -1768,7 +1768,7 @@ class SpSum(gof.op.Op):
             r = SparseFromDense(o_format)(r)
         return [r]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         r = None
         if self.axis is None:
             r = [()]
@@ -1841,7 +1841,7 @@ class Diag(gof.op.Op):
         (gz,) = gout
         return [square_diagonal(gz)]
 
-    def infer_shape(self, nodes, shapes):
+    def infer_shape(self, fgraph, nodes, shapes):
         return [(tensor.minimum(*shapes[0]),)]
 
 
@@ -1895,7 +1895,7 @@ class SquareDiagonal(gof.op.Op):
         (gz,) = gout
         return [diag(gz)]
 
-    def infer_shape(self, nodes, shapes):
+    def infer_shape(self, fgraph, nodes, shapes):
         return [(shapes[0][0], shapes[0][0])]
 
 
@@ -1946,7 +1946,7 @@ class EnsureSortedIndices(gof.op.Op):
     def grad(self, inputs, output_grad):
         return [output_grad[0]]
 
-    def infer_shape(self, node, i0_shapes):
+    def infer_shape(self, fgraph, node, i0_shapes):
         return i0_shapes
 
     def __str__(self):
@@ -2038,7 +2038,7 @@ class AddSS(gof.op.Op):
         assert _is_sparse_variable(gz)
         return gz, gz
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -2076,7 +2076,7 @@ class AddSSData(gof.op.Op):
         derivative = {True: gz, False: None}
         return [derivative[b] for b in is_continuous]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[0]]
 
 
@@ -2140,7 +2140,7 @@ class AddSD(gof.op.Op):
         assert _is_dense_variable(gz)
         return sp_ones_like(x) * gz, gz
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[1]]
 
 
@@ -2178,7 +2178,7 @@ class StructuredAddSV(gof.op.Op):
         assert _is_sparse_variable(gz)
         return gz, sp_sum(gz, axis=0, sparse_grad=True)
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[0]]
 
 
@@ -2319,7 +2319,7 @@ class MulSS(gof.op.Op):
         (gz,) = gout
         return y * gz, x * gz
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -2412,7 +2412,7 @@ class MulSD(gof.op.Op):
         assert _is_sparse_variable(gz)
         return y * gz, dense_from_sparse(x * gz)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -2462,7 +2462,7 @@ class MulSV(gof.op.Op):
 
         return mul_s_v(gz, y), sp_sum(x * gz, axis=0, sparse_grad=True)
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[0]]
 
 
@@ -2582,7 +2582,7 @@ class __ComparisonOpSS(gof.op.Op):
         assert x.shape == y.shape
         out[0] = self.comparison(x, y).astype("uint8")
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[0]]
 
 
@@ -2627,7 +2627,7 @@ class __ComparisonOpSD(gof.op.Op):
         o = np.asarray(o)
         out[0] = o
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[0]]
 
 
@@ -2968,7 +2968,7 @@ class HStack(gof.op.Op):
 
         return [choose(c, d) for c, d in zip(is_continuous, derivative)]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         def _get(l):
             return l[1]
 
@@ -3050,7 +3050,7 @@ class VStack(HStack):
 
         return [choose(c, d) for c, d in zip(is_continuous, derivative)]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         def _get(l):
             return l[0]
 
@@ -3127,7 +3127,7 @@ class Remove0(gof.Op):
         (gz,) = gout
         return [gz]
 
-    def infer_shape(self, node, i0_shapes):
+    def infer_shape(self, fgraph, node, i0_shapes):
         return i0_shapes
 
 
@@ -3515,7 +3515,7 @@ class TrueDot(gof.op.Op):
                 rval[1] = dense_from_sparse(rval[1])
         return rval
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [(shapes[0][0], shapes[1][1])]
 
 
@@ -3647,7 +3647,7 @@ class StructuredDot(gof.Op):
         (g_out,) = gout
         return [structured_dot_grad(a, b, g_out), structured_dot(a.T, g_out)]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [(shapes[0][0], shapes[1][1])]
 
 
@@ -3832,7 +3832,7 @@ class StructuredDotGradCSC(gof.Op):
             locals(), **sub
         )
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -3969,7 +3969,7 @@ class StructuredDotGradCSR(gof.Op):
             locals(), **sub
         )
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -4033,7 +4033,7 @@ class SamplingDot(gof.op.Op):
 
         return rval
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[2]]
 
 
@@ -4083,7 +4083,7 @@ class Dot(gof.op.Op):
     def __str__(self):
         return "Sparse" + self.__class__.__name__
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         xshp, yshp = shapes
         x, y = node.inputs
         if x.ndim == 2 and y.ndim == 2:
@@ -4379,7 +4379,7 @@ class ConstructSparseFromList(gof.Op):
             (data, indices, indptr), shape=out_shape, dtype=values.dtype
         )
 
-    def infer_shape(self, node, ishapes):
+    def infer_shape(self, fgraph, node, ishapes):
         x = node.inputs[0]
         return [[x[0], x[1]]]
 

--- a/theano/sparse/opt.py
+++ b/theano/sparse/opt.py
@@ -181,7 +181,7 @@ class AddSD_ccode(gof.op.Op):
         )
         return code
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[3]]
 
     def c_code_cache_version(self):

--- a/theano/sparse/opt.py
+++ b/theano/sparse/opt.py
@@ -25,7 +25,7 @@ _is_dense = sparse._is_dense
 
 
 @gof.local_optimizer([csm_properties])
-def local_csm_properties_csm(node):
+def local_csm_properties_csm(fgraph, node):
     """
     If we find csm_properties(CSM(*args)), then we can replace that with the
     *args directly.
@@ -50,7 +50,7 @@ register_specialize(local_csm_properties_csm)
 
 # This is tested in tests/test_basic.py:test_remove0
 @gof.local_optimizer([sparse.Remove0])
-def local_inplace_remove0(node):
+def local_inplace_remove0(fgraph, node):
     """
     Optimization to insert inplace versions of Remove0.
 
@@ -189,7 +189,7 @@ class AddSD_ccode(gof.op.Op):
 
 
 @gof.local_optimizer([sparse.AddSD])
-def local_inplace_addsd_ccode(node):
+def local_inplace_addsd_ccode(fgraph, node):
     """
     Optimization to insert inplace versions of AddSD.
 
@@ -219,7 +219,7 @@ theano.compile.optdb.register(
 @register_canonicalize("fast_compile")
 @register_specialize
 @gof.local_optimizer([sparse.DenseFromSparse])
-def local_dense_from_sparse_sparse_from_dense(node):
+def local_dense_from_sparse_sparse_from_dense(fgraph, node):
     if isinstance(node.op, sparse.DenseFromSparse):
         inp = node.inputs[0]
         if inp.owner and isinstance(inp.owner.op, sparse.SparseFromDense):
@@ -227,7 +227,7 @@ def local_dense_from_sparse_sparse_from_dense(node):
 
 
 @gof.local_optimizer([sparse.AddSD])
-def local_addsd_ccode(node):
+def local_addsd_ccode(fgraph, node):
     """
     Convert AddSD to faster AddSD_ccode.
 
@@ -639,7 +639,7 @@ sd_csr = StructuredDotCSR()
 # register a specialization to replace StructuredDot -> StructuredDotCSx
 # This is tested in tests/test_basic.py:792
 @gof.local_optimizer([sparse._structured_dot])
-def local_structured_dot(node):
+def local_structured_dot(fgraph, node):
     if node.op == sparse._structured_dot:
         a, b = node.inputs
         if a.type.format == "csc":
@@ -951,7 +951,7 @@ register_specialize(local_usmm, name="local_usmm")
 # register a specialization to replace usmm_csc_dense -> usmm_csc_dense_inplace
 # This is tested in tests/test_basic.py:UsmmTests
 @gof.local_optimizer([usmm_csc_dense])
-def local_usmm_csc_dense_inplace(node):
+def local_usmm_csc_dense_inplace(fgraph, node):
     if node.op == usmm_csc_dense:
         return [usmm_csc_dense_inplace(*node.inputs)]
 
@@ -961,7 +961,7 @@ register_specialize(local_usmm_csc_dense_inplace, "cxx_only", "inplace")
 
 # This is tested in tests/test_basic.py:UsmmTests
 @gof.local_optimizer([usmm])
-def local_usmm_csx(node):
+def local_usmm_csx(fgraph, node):
     """
     usmm -> usmm_csc_dense
 
@@ -1121,7 +1121,7 @@ csm_grad_c = CSMGradC()
 # register a specialization to replace csm_grad -> csm_grad_c
 # This is tested in tests/test_opt.py:test_local_csm_grad_c
 @gof.local_optimizer([csm_grad(None)])
-def local_csm_grad_c(node):
+def local_csm_grad_c(fgraph, node):
     """
     csm_grad(None) -> csm_grad_c
 
@@ -1411,7 +1411,7 @@ mul_s_d_csr = MulSDCSR()
 
 # register a specialization to replace MulSD -> MulSDCSX
 @gof.local_optimizer([sparse.mul_s_d])
-def local_mul_s_d(node):
+def local_mul_s_d(fgraph, node):
     if node.op == sparse.mul_s_d:
         x, y = node.inputs
 
@@ -1591,7 +1591,7 @@ mul_s_v_csr = MulSVCSR()
 
 # register a specialization to replace MulSV -> MulSVCSR
 @gof.local_optimizer([sparse.mul_s_v])
-def local_mul_s_v(node):
+def local_mul_s_v(fgraph, node):
     if node.op == sparse.mul_s_v:
         x, y = node.inputs
 
@@ -1769,7 +1769,7 @@ structured_add_s_v_csr = StructuredAddSVCSR()
 # register a specialization to replace
 # structured_add_s_v -> structured_add_s_v_csr
 @gof.local_optimizer([sparse.structured_add_s_v])
-def local_structured_add_s_v(node):
+def local_structured_add_s_v(fgraph, node):
     if node.op == sparse.structured_add_s_v:
         x, y = node.inputs
 
@@ -2056,7 +2056,7 @@ sampling_dot_csr = SamplingDotCSR()
 
 # register a specialization to replace SamplingDot -> SamplingDotCsr
 @gof.local_optimizer([sparse.sampling_dot])
-def local_sampling_dot_csr(node):
+def local_sampling_dot_csr(fgraph, node):
     if not theano.config.blas.ldflags:
         # The C implementation of SamplingDotCsr relies on BLAS routines
         return

--- a/theano/sparse/sandbox/sp2.py
+++ b/theano/sparse/sandbox/sp2.py
@@ -68,7 +68,7 @@ class Poisson(gof.op.Op):
             )
         ]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return ins_shapes
 
 
@@ -134,7 +134,7 @@ class Binomial(gof.op.Op):
             theano.gradient.disconnected_type(),
         ]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [(node.inputs[2][0], node.inputs[2][1])]
 
 
@@ -213,7 +213,7 @@ class Multinomial(gof.op.Op):
             ),
         ]
 
-    def infer_shape(self, node, ins_shapes):
+    def infer_shape(self, fgraph, node, ins_shapes):
         return [ins_shapes[1]]
 
 

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -3213,11 +3213,12 @@ class Alloc(gof.Op):
         return self(eval_points[0], *inputs[1:], **dict(return_list=True))
 
     def do_constant_folding(self, fgraph, node):
-        if not getattr(node.outputs[0], "clients", []):
-            # If there are no clients then there is no point doing constant
-            # folding.
+        clients = fgraph.clients[node.outputs[0]]
+
+        if not clients:
             return False
-        for client in node.outputs[0].clients:
+
+        for client in clients:
             if client[0] == "output":
                 # If the output is a constant, it will have to be deepcopied
                 # each time the function is called.  So we do not fold.

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -3212,7 +3212,7 @@ class Alloc(gof.Op):
             return [None]
         return self(eval_points[0], *inputs[1:], **dict(return_list=True))
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         if not getattr(node.outputs[0], "clients", []):
             # If there are no clients then there is no point doing constant
             # folding.
@@ -7250,7 +7250,7 @@ class AllocEmpty(gof.Op):
     def c_code_cache_version(self):
         return (4,)
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         return False
 
     def connection_pattern(self, node):

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -1164,7 +1164,7 @@ class TensorFromScalar(Op):
         (out,) = out_
         out[0] = np.asarray(s)
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         return [()]
 
     def grad(self, inp, grads):
@@ -1203,7 +1203,7 @@ class ScalarFromTensor(Op):
         (out,) = out_
         out[0] = s.flatten()[0]
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         return [()]
 
     def grad(self, inp, grads):
@@ -1467,7 +1467,7 @@ class MaxAndArgmax(Op):
     def c_code_cache_version(self):
         return (5,)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         ishape = shapes[0]
         rval = tuple(
             ishape[i]
@@ -1667,7 +1667,7 @@ class Argmax(Op):
     def c_code_cache_version(self):
         return (1,)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         (ishape,) = shapes
         if self.axis is None:
             return [()]
@@ -2849,7 +2849,7 @@ class Tri(gof.Op):
         (out,) = out_
         out[0] = np.tri(N, M, k, dtype=self.dtype)
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         out_shape = [node.inputs[0], node.inputs[1]]
         return [out_shape]
 
@@ -2963,7 +2963,7 @@ class Eye(gof.Op):
         (out,) = out_
         out[0] = np.eye(n, m, k, dtype=self.dtype)
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         out_shape = [node.inputs[0], node.inputs[1]]
         return [out_shape]
 
@@ -3139,7 +3139,7 @@ class Alloc(gof.Op):
     def c_code_cache_version(self):
         return (2,)
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [node.inputs[1:]]
 
     def connection_pattern(self, node):
@@ -3183,29 +3183,6 @@ class Alloc(gof.Op):
         # shape by epsilon, the existing elements do not
         # change.
         return [gx] + [DisconnectedType()() for i in inputs[1:]]
-
-    def __call__(self, val, *shapes, **kwargs):
-        """
-        If the alloc would be useless, this function returns val.
-
-        If this function is called outside of a graph optimization context
-        (for instance, it is manually called by a user building a graph),
-        then we always return an Alloc node, to allow for DebugMode to check
-        for size mismatches.
-
-        If you always want an Alloc node, call make_node.
-
-        """
-        ret = super().__call__(val, *shapes, **kwargs)
-        try:
-            # It makes optimization difficult when useless allocs are thrown
-            # into the graph at every stage of optimization.  This little logic
-            # tries to help at least in some cases.
-            if hasattr(val, "fgraph") and (val.type == ret.type):
-                return val
-        except AttributeError:
-            pass
-        return ret
 
     def R_op(self, inputs, eval_points):
         if eval_points[0] is None:
@@ -4021,7 +3998,7 @@ class Split(Op):
             outputs[i][0] = x.__getitem__(tuple(general_key)).copy()
             lower_idx = upper_idx
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         axis = node.inputs[1]
         splits = node.inputs[2]
         shp_x, shp_axis, shp_splits = in_shapes
@@ -4587,7 +4564,7 @@ class Join(Op):
 
         return rval
 
-    def infer_shape(self, node, ishapes):
+    def infer_shape(self, fgraph, node, ishapes):
         # ishapes[0] contains the size of the axis on which we join
         # Join op should get at least one input to join
         assert len(ishapes) > 1
@@ -5126,7 +5103,7 @@ class Reshape(Op):
             return [None]
         return self(eval_points[0], *inputs[1:], **dict(return_list=True))
 
-    def infer_shape(self, node, ishapes):
+    def infer_shape(self, fgraph, node, ishapes):
         # inputs[1] can contain at most one value of '-1', meaning the actual
         # shape of the output will be automatically computed by reshape, so
         # that the total number of elements stays the same.
@@ -5325,7 +5302,7 @@ class Flatten(Op):
             newshape = x.shape[: outdim - 1] + (np.prod(x.shape[outdim - 1 :]),)
             out[0] = x.reshape(newshape)
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         (in_shp,) = in_shapes
         part1 = in_shp[: self.outdim - 1]
         part2 = in_shp[self.outdim - 1 :]
@@ -5572,7 +5549,7 @@ class Tile(Op):
                 res = res.copy()
         out[0] = res
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         # Note: in contrast with numpy, it is assumed that x.shape and reps
         # have equal length;  see also tile function below
 
@@ -5709,7 +5686,7 @@ class ARange(Op):
         return Apply(self, inputs, outputs)
 
     @theano.configparser.change_flags(warn_float64="ignore")
-    def infer_shape(self, node, i_shapes):
+    def infer_shape(self, fgraph, node, i_shapes):
         # Note start, stop and step can be float numbers.
         start, stop, step = node.inputs
 
@@ -6061,7 +6038,7 @@ class PermuteRowElements(Op):
 
         self._rec_perform(node, x, y, inverse, outs[0], curdim=0)
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         shp_x = in_shapes[0]
         shp_y = in_shapes[1]
         assert len(shp_x) == len(shp_y)
@@ -6269,7 +6246,7 @@ class Dot(Op):
         else:
             return [t2]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         xshp, yshp = shapes
         x, y = node.inputs
 
@@ -6744,7 +6721,7 @@ class ExtractDiag(Op):
             )
             return [grad_not_implemented(self, 0, x)]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         (in_shape,) = shapes
         dim1 = in_shape[self.axis1]
         dim2 = in_shape[self.axis2]
@@ -6903,7 +6880,7 @@ class AllocDiag(Op):
         (gz,) = gout
         return [diagonal(gz, offset=self.offset, axis1=self.axis1, axis2=self.axis2)]
 
-    def infer_shape(self, nodes, shapes):
+    def infer_shape(self, fgraph, nodes, shapes):
         (x_shape,) = shapes
         axis1 = np.minimum(self.axis1, self.axis2)
         axis2 = np.maximum(self.axis1, self.axis2)
@@ -7109,7 +7086,7 @@ class Choose(Op):
         assert mode in ("raise", "wrap", "clip")
         self.mode = mode
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
 
         a_shape, choices_shape = shapes
         out_shape = theano.tensor.extra_ops.broadcast_shape(
@@ -7136,7 +7113,7 @@ class Choose(Op):
         else:
             choice = as_tensor_variable(choices)
         (out_shape,) = self.infer_shape(
-            None, [tuple(a.shape), tuple(theano.tensor.basic.shape(choice))]
+            None, None, [tuple(a.shape), tuple(theano.tensor.basic.shape(choice))]
         )
 
         bcast = []
@@ -7245,7 +7222,7 @@ class AllocEmpty(gof.Op):
         )
         return str
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [node.inputs]
 
     def c_code_cache_version(self):

--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -147,9 +147,9 @@ from theano.compile.mode import optdb
 from theano.gof import (
     Apply,
     EquilibriumOptimizer,
+    GlobalOptimizer,
     InconsistencyError,
     Op,
-    Optimizer,
     ReplacementDidNotRemoveError,
     SequenceDB,
     local_optimizer,
@@ -1449,11 +1449,11 @@ def _gemm_from_node2(node):
     return None, t1 - t0, 0, 0
 
 
-class GemmOptimizer(Optimizer):
+class GemmOptimizer(GlobalOptimizer):
     """Graph optimizer for inserting Gemm operations."""
 
     def __init__(self):
-        Optimizer.__init__(self)
+        super().__init__()
         self.warned = False
 
     def add_requirements(self, fgraph):

--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -303,7 +303,7 @@ class Gemv(Op):
                     out += y
             out_storage[0][0] = np.asarray(out, dtype=y.dtype)
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]
 
 
@@ -372,7 +372,7 @@ class Ger(Op):
             A += np.outer(cx, cy)
         cZ[0] = A
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]
 
 
@@ -969,7 +969,7 @@ class Gemm(GemmRelated):
                 z += a * np.dot(x, y)
             zout[0] = z
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]
 
     setup_z_Nz_Sz_inplace = """
@@ -1599,7 +1599,7 @@ class Dot22(GemmRelated):
             e.args = e.args + (x.shape, y.shape)
             raise
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [[input_shapes[0][0], input_shapes[1][1]]]
 
     setup_z_Nz_Sz = """
@@ -1874,7 +1874,7 @@ class Dot22Scalar(GemmRelated):
             e.args = e.args + (x.shape, y.shape)
             raise
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [[input_shapes[0][0], input_shapes[1][1]]]
 
     setup_z_Nz_Sz = Dot22.setup_z_Nz_Sz
@@ -2099,7 +2099,7 @@ class BatchedDot(Op):
                 f" same size in axis 0, but have sizes [{', '.join([str(i.shape[0]) for i in inp])}]."
             )
 
-        shape = self.infer_shape(node, [i.shape for i in inp])[0]
+        shape = self.infer_shape(None, node, [i.shape for i in inp])[0]
         dtype = node.outputs[0].dtype
         z0 = z[0] = np.empty(shape, dtype=dtype)
         for i in range(z0.shape[0]):
@@ -2523,7 +2523,7 @@ class BatchedDot(Op):
         else:
             return [t2]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         for shape_ in shapes:
             if len(shape_) not in (2, 3):
                 raise NotImplementedError()

--- a/theano/tensor/blas_c.py
+++ b/theano/tensor/blas_c.py
@@ -348,7 +348,7 @@ cger_no_inplace = CGer(False)
 
 
 @local_optimizer([ger, ger_destructive])
-def use_c_ger(node):
+def use_c_ger(fgraph, node):
     if not config.blas.ldflags:
         return
     # Only float32 and float64 are supported for now.
@@ -359,7 +359,7 @@ def use_c_ger(node):
 
 
 @local_optimizer([CGer(False)])
-def make_c_ger_destructive(node):
+def make_c_ger_destructive(fgraph, node):
     if isinstance(node.op, CGer) and not node.op.destructive:
         return [cger_inplace(*node.inputs)]
 
@@ -703,7 +703,7 @@ check_force_gemv_init._force_init_beta = None
 
 
 @local_optimizer([gemv_inplace, gemv_no_inplace])
-def use_c_gemv(node):
+def use_c_gemv(fgraph, node):
     if not config.blas.ldflags:
         return
     # Only float32 and float64 are supported for now.
@@ -714,7 +714,7 @@ def use_c_gemv(node):
 
 
 @local_optimizer([CGemv(inplace=False)])
-def make_c_gemv_destructive(node):
+def make_c_gemv_destructive(fgraph, node):
     if isinstance(node.op, CGemv) and not node.op.inplace:
         inputs = list(node.inputs)
         dest = inputs[0]

--- a/theano/tensor/blas_c.py
+++ b/theano/tensor/blas_c.py
@@ -721,7 +721,7 @@ def make_c_gemv_destructive(fgraph, node):
         if (
             dest.owner
             and isinstance(dest.owner.op, tt.AllocEmpty)
-            and len(dest.clients) > 1
+            and len(fgraph.clients[dest]) > 1
         ):
             inputs[0] = tt.AllocEmpty(dest.dtype)(*dest.owner.inputs)
 

--- a/theano/tensor/blas_scipy.py
+++ b/theano/tensor/blas_scipy.py
@@ -59,13 +59,13 @@ scipy_ger_inplace = ScipyGer(True)
 
 
 @local_optimizer([ger, ger_destructive])
-def use_scipy_ger(node):
+def use_scipy_ger(fgraph, node):
     if node.op == ger:
         return [scipy_ger_no_inplace(*node.inputs)]
 
 
 @local_optimizer([scipy_ger_no_inplace])
-def make_ger_destructive(node):
+def make_ger_destructive(fgraph, node):
     if node.op == scipy_ger_no_inplace:
         return [scipy_ger_inplace(*node.inputs)]
 

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -281,7 +281,7 @@ class DimShuffle(COp):
 
         storage[0] = np.asarray(res)  # asarray puts scalars back into array
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         (ishp,) = shapes
         # transpose
         rval = [ishp[i] for i in self.shuffle]
@@ -866,7 +866,7 @@ second dimension
                 storage[0] = variable
             i += 1
 
-    def infer_shape(self, node, i_shapes):
+    def infer_shape(self, fgraph, node, i_shapes):
         rval = []
         for o in node.outputs:
             oshp = []
@@ -1481,7 +1481,7 @@ class CAReduce(Op):
             # Force a copy
             output[0] = np.array(variable, copy=True, dtype=node.outputs[0].type.dtype)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         (ishape,) = shapes
         axis = self.axis
         if axis is None:

--- a/theano/tensor/fourier.py
+++ b/theano/tensor/fourier.py
@@ -89,7 +89,7 @@ class Fourier(gof.Op):
             [tensor.TensorType("complex128", a.type.broadcastable)()],
         )
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         shape_a = in_shapes[0]
         n = node.inputs[1]
         axis = node.inputs[2]

--- a/theano/tensor/io.py
+++ b/theano/tensor/io.py
@@ -159,7 +159,7 @@ class MPIRecv(Op):
     def __str__(self):
         return f"MPIRecv{{source: {int(self.source)}, tag: {int(self.tag)}, shape: {self.shape}, dtype: {self.dtype}}}"
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [None, self.shape]
 
     def do_constant_folding(self, fgraph, node):
@@ -201,7 +201,7 @@ class MPIRecvWait(Op):
 
         out[0][0] = data
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[1]]
 
     view_map = {0: [1]}

--- a/theano/tensor/io.py
+++ b/theano/tensor/io.py
@@ -162,7 +162,7 @@ class MPIRecv(Op):
     def infer_shape(self, node, shapes):
         return [None, self.shape]
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         return False
 
 

--- a/theano/tensor/nlinalg.py
+++ b/theano/tensor/nlinalg.py
@@ -144,7 +144,7 @@ class MatrixInverse(Op):
             return [None]
         return [-matrix_dot(xi, ev, xi)]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return shapes
 
 
@@ -194,7 +194,7 @@ class AllocDiag(Op):
             raise TypeError(x)
         z[0] = np.diag(x)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         (x_s,) = shapes
         return [(x_s[0], x_s[0])]
 
@@ -261,7 +261,7 @@ class Det(Op):
         (x,) = inputs
         return [gz * self(x) * matrix_inverse(x).T]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [()]
 
     def __str__(self):
@@ -292,7 +292,7 @@ class Eig(Op):
         (w, v) = outputs
         w[0], v[0] = [z.astype(x.dtype) for z in self._numop(x)]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         n = shapes[0][0]
         return [(n,), (n, n)]
 
@@ -434,7 +434,7 @@ class EighGrad(Op):
         # upcasting in self.tri0.
         outputs[0][0] = np.asarray(out, dtype=node.outputs[0].dtype)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -599,7 +599,7 @@ class SVD(Op):
             (s,) = outputs
             s[0] = self._numop(x, self.full_matrices, self.compute_uv)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         (x_shape,) = shapes
         M, N = x_shape
         K = tensor.minimum(M, N)
@@ -762,7 +762,7 @@ class TensorInv(Op):
         (x,) = outputs
         x[0] = self._numop(a, self.ind)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         sp = shapes[0][self.ind :] + shapes[0][: self.ind]
         return [sp]
 

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -812,7 +812,7 @@ def separable_conv2d(
         depthwise_op_shape = None
     else:
         depthwise_op_shape = conv_op.infer_shape(
-            None, [input_shape, depthwise_filter_shape]
+            None, None, [input_shape, depthwise_filter_shape]
         )[0]
     depthwise_op = conv_op(input, depthwise_filters)
 
@@ -944,7 +944,7 @@ def separable_conv3d(
         depthwise_op_shape = None
     else:
         depthwise_op_shape = conv_op.infer_shape(
-            None, [input_shape, depthwise_filter_shape]
+            None, None, [input_shape, depthwise_filter_shape]
         )[0]
     depthwise_op = conv_op(input, depthwise_filters)
 
@@ -2688,7 +2688,7 @@ class AbstractConv(BaseAbstractConv):
                 rval += self.make_node(inputs[0], eval_points[1]).outputs[0]
         return [rval]
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         imshp = input_shapes[0]
         kshp = input_shapes[1]
 
@@ -3033,7 +3033,7 @@ class AbstractConv_gradWeights(BaseAbstractConv):
     def connection_pattern(self, node):
         return [[1], [1], [0]]  # no connection to height, width
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         # We use self.kshp (that was passed when creating the Op) if possible,
         # or fall back to the `shape` input of the node.
         # TODO: when there is no subsampling, try to infer the kernel shape
@@ -3439,7 +3439,7 @@ class AbstractConv_gradInputs(BaseAbstractConv):
     def connection_pattern(self, node):
         return [[1], [1], [0]]  # no connection to height, width
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         # We use self.imshp (that was passed when creating the Op) if possible,
         # or fall back to the `shape` input of the node.
         # TODO: when there is no subsampling, try to infer the image shape

--- a/theano/tensor/nnet/abstract_conv.py
+++ b/theano/tensor/nnet/abstract_conv.py
@@ -2311,7 +2311,7 @@ class BaseAbstractConv(Op):
             )
         self.unshared = unshared
 
-    def do_constant_folding(self, node):
+    def do_constant_folding(self, fgraph, node):
         # Disable constant folding since there is no implementation.
         # This may change in the future.
         return False

--- a/theano/tensor/nnet/blocksparse.py
+++ b/theano/tensor/nnet/blocksparse.py
@@ -110,7 +110,7 @@ class SparseBlockGemv(Op):
                     o[b, j, :] += np.dot(h[b, i], w)
         out_[0][0] = o
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]
 
     def grad(self, inputs, grads):
@@ -200,7 +200,7 @@ class SparseBlockOuter(Op):
 
         return Apply(self, [o, x, y, xIdx, yIdx, alpha], [o.type()])
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         return [input_shapes[0]]
 
     def perform(self, node, inp, out_):

--- a/theano/tensor/nnet/bn.py
+++ b/theano/tensor/nnet/bn.py
@@ -774,7 +774,7 @@ class AbstractBatchNormTrainGrad(Op):
 
 
 @local_optimizer([AbstractBatchNormTrain])
-def local_abstract_batch_norm_train(node):
+def local_abstract_batch_norm_train(fgraph, node):
     if not isinstance(node.op, AbstractBatchNormTrain):
         return None
 
@@ -833,7 +833,7 @@ def local_abstract_batch_norm_train(node):
 
 
 @local_optimizer([AbstractBatchNormTrainGrad])
-def local_abstract_batch_norm_train_grad(node):
+def local_abstract_batch_norm_train_grad(fgraph, node):
     if not isinstance(node.op, AbstractBatchNormTrainGrad):
         return None
 
@@ -872,7 +872,7 @@ def local_abstract_batch_norm_train_grad(node):
 
 
 @local_optimizer([AbstractBatchNormInference])
-def local_abstract_batch_norm_inference(node):
+def local_abstract_batch_norm_inference(fgraph, node):
     if not isinstance(node.op, AbstractBatchNormInference):
         return None
 

--- a/theano/tensor/nnet/bn.py
+++ b/theano/tensor/nnet/bn.py
@@ -432,7 +432,7 @@ class AbstractBatchNormTrain(Op):
         axes = tuple(int(a) for a in axes)
         self.axes = axes
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[0]] + [shape[1]] * (len(node.outputs) - 1)
 
     def make_node(
@@ -568,7 +568,7 @@ class AbstractBatchNormInference(Op):
         axes = tuple(int(a) for a in axes)
         self.axes = axes
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[0]]
 
     def make_node(
@@ -749,7 +749,7 @@ class AbstractBatchNormTrainGrad(Op):
             [False, False, False],
         ]  # epsilon
 
-    def infer_shape(self, node, shape):
+    def infer_shape(self, fgraph, node, shape):
         return [shape[0], shape[2], shape[2]]
 
     def perform(self, node, inputs, output_storage):

--- a/theano/tensor/nnet/conv.py
+++ b/theano/tensor/nnet/conv.py
@@ -771,7 +771,7 @@ class ConvOp(OpenMPOp):
 
         return Apply(self, [_inputs, _kerns], [output])
 
-    def infer_shape(self, node, input_shapes):
+    def infer_shape(self, fgraph, node, input_shapes):
         imshp = input_shapes[0]  # 4D image shape
         kshp = input_shapes[1]  # 4D filter shape
         bsize, imshp = imshp[0], list(imshp[1:])

--- a/theano/tensor/nnet/conv3d2d.py
+++ b/theano/tensor/nnet/conv3d2d.py
@@ -301,7 +301,7 @@ def conv3d(
 
 
 @theano.gof.local_optimizer([DiagonalSubtensor, IncDiagonalSubtensor])
-def local_inplace_DiagonalSubtensor(node):
+def local_inplace_DiagonalSubtensor(fgraph, node):
     """Also work for IncDiagonalSubtensor."""
     if (
         isinstance(node.op, (DiagonalSubtensor, IncDiagonalSubtensor))

--- a/theano/tensor/nnet/corr.py
+++ b/theano/tensor/nnet/corr.py
@@ -697,7 +697,7 @@ class CorrMM(BaseCorrMM):
         dtype = img.type.dtype
         return Apply(self, [img, kern], [TensorType(dtype, broadcastable)()])
 
-    def infer_shape(self, node, input_shape):
+    def infer_shape(self, fgraph, node, input_shape):
         imshp = input_shape[0]
         kshp = input_shape[1]
         res = get_conv_output_shape(
@@ -786,7 +786,7 @@ class CorrMM_gradWeights(BaseCorrMM):
             self, [img, topgrad] + height_width, [TensorType(dtype, broadcastable)()]
         )
 
-    def infer_shape(self, node, input_shape):
+    def infer_shape(self, fgraph, node, input_shape):
         if self.border_mode == "half":
             padH_l = padH_r = padW_l = padW_r = -1
         elif self.border_mode == "full":
@@ -914,7 +914,7 @@ class CorrMM_gradInputs(BaseCorrMM):
             self, [kern, topgrad] + height_width, [TensorType(dtype, broadcastable)()]
         )
 
-    def infer_shape(self, node, input_shape):
+    def infer_shape(self, fgraph, node, input_shape):
         if self.border_mode == "half":
             padH_l = padH_r = padW_l = padW_r = -1
         elif self.border_mode == "full":

--- a/theano/tensor/nnet/corr3d.py
+++ b/theano/tensor/nnet/corr3d.py
@@ -637,7 +637,7 @@ class Corr3dMM(BaseCorr3dMM):
         dtype = img.type.dtype
         return Apply(self, [img, kern], [TensorType(dtype, broadcastable)()])
 
-    def infer_shape(self, node, input_shape):
+    def infer_shape(self, fgraph, node, input_shape):
         imshp = input_shape[0]
         kshp = input_shape[1]
         res = get_conv_output_shape(
@@ -718,7 +718,7 @@ class Corr3dMMGradWeights(BaseCorr3dMM):
             [TensorType(dtype, broadcastable)()],
         )
 
-    def infer_shape(self, node, input_shape):
+    def infer_shape(self, fgraph, node, input_shape):
         if self.border_mode == "half":
             padH = padW = padD = -1
         elif self.border_mode == "full":
@@ -841,7 +841,7 @@ class Corr3dMMGradInputs(BaseCorr3dMM):
             [TensorType(dtype, broadcastable)()],
         )
 
-    def infer_shape(self, node, input_shape):
+    def infer_shape(self, fgraph, node, input_shape):
         if self.border_mode == "half":
             padH = padW = padD = -1
         elif self.border_mode == "full":

--- a/theano/tensor/nnet/ctc.py
+++ b/theano/tensor/nnet/ctc.py
@@ -249,7 +249,7 @@ def ctc(activations, labels, input_lengths):
 def local_ctc_no_grad(fgraph, node):
     if isinstance(node.op, ConnectionistTemporalClassification):
         if len(node.outputs) > 1:
-            if len(node.outputs[1].clients) == 0:  # gradient is not used
+            if len(fgraph.clients[node.outputs[1]]) == 0:  # gradient is not used
                 return [
                     ConnectionistTemporalClassification(compute_grad=False)(
                         *node.inputs

--- a/theano/tensor/nnet/ctc.py
+++ b/theano/tensor/nnet/ctc.py
@@ -246,7 +246,7 @@ def ctc(activations, labels, input_lengths):
 # Disable gradient computation if not needed
 @register_canonicalize("fast_compile")
 @local_optimizer([ConnectionistTemporalClassification])
-def local_ctc_no_grad(node):
+def local_ctc_no_grad(fgraph, node):
     if isinstance(node.op, ConnectionistTemporalClassification):
         if len(node.outputs) > 1:
             if len(node.outputs[1].clients) == 0:  # gradient is not used

--- a/theano/tensor/nnet/neighbours.py
+++ b/theano/tensor/nnet/neighbours.py
@@ -344,7 +344,7 @@ class Images2Neibs(Op):
                                     else:
                                         z[0][z_row, z_col] = ten4[n, s, ten4_2, ten4_3]
 
-    def infer_shape(self, node, input_shape):
+    def infer_shape(self, fgraph, node, input_shape):
         in_shape = input_shape[0]
         c, d = node.inputs[1]
         step_x, step_y = node.inputs[2]

--- a/theano/tensor/nnet/nnet.py
+++ b/theano/tensor/nnet/nnet.py
@@ -1647,7 +1647,7 @@ def local_argmax_pushdown(fgraph, node):
     if (
         isinstance(node.op, MaxAndArgmax)
         and node.inputs[0].owner
-        and len(node.outputs[0].clients) > 0
+        and len(fgraph.clients[node.outputs[0]]) > 0
         and node.inputs[0].owner.op
         in (
             softmax_op,
@@ -1673,7 +1673,7 @@ def local_argmax_pushdown(fgraph, node):
     if (
         isinstance(node.op, MaxAndArgmax)
         and node.inputs[0].owner
-        and len(node.outputs[0].clients) == 0
+        and len(fgraph.clients[node.outputs[0]]) == 0
     ):
         x_max, x_argmax = node.outputs
         x = node.inputs[0]
@@ -2021,10 +2021,10 @@ def local_advanced_indexing_crossentropy_onehot_grad(fgraph, node):
 def graph_merge_softmax_with_crossentropy_softmax(fgraph, node):
     if node.op == softmax_with_bias:
         x, b = node.inputs
-        for x_client in x.clients:
+        for x_client in fgraph.clients[x]:
             if x_client[0].op == crossentropy_softmax_argmax_1hot_with_bias:
                 big_client = x_client[0]
-                if big_client in [b_client[0] for b_client in b.clients]:
+                if big_client in [b_client[0] for b_client in fgraph.clients[b]]:
                     xx, bb, ll = big_client.inputs
                     mergeable_client = big_client.op(x, b, ll)
                     copy_stack_trace(node.outputs[0], mergeable_client[1])

--- a/theano/tensor/nnet/opt.py
+++ b/theano/tensor/nnet/opt.py
@@ -35,7 +35,7 @@ from theano.tensor.type import TensorType
 
 
 @gof.local_optimizer([SparseBlockGemv], inplace=True)
-def local_inplace_sparse_block_gemv(node):
+def local_inplace_sparse_block_gemv(fgraph, node):
     """
     SparseBlockGemv(inplace=False) -> SparseBlockGemv(inplace=True)
     """
@@ -58,7 +58,7 @@ compile.optdb.register(
 
 
 @gof.local_optimizer([SparseBlockOuter], inplace=True)
-def local_inplace_sparse_block_outer(node):
+def local_inplace_sparse_block_outer(fgraph, node):
     """
     SparseBlockOuter(inplace=False) -> SparseBlockOuter(inplace=True)
     """
@@ -83,7 +83,7 @@ compile.optdb.register(
 
 # Conv opts
 @local_optimizer([AbstractConv2d])
-def local_abstractconv_gemm(node):
+def local_abstractconv_gemm(fgraph, node):
     # If theano.config.blas.ldflags is empty, Theano will use
     # a NumPy C implementation of [sd]gemm_.
     if theano.config.cxx == "" or node.inputs[0].dtype == "float16":
@@ -111,7 +111,7 @@ def local_abstractconv_gemm(node):
 
 
 @local_optimizer([AbstractConv3d])
-def local_abstractconv3d_gemm(node):
+def local_abstractconv3d_gemm(fgraph, node):
     # If theano.config.blas.ldflags is empty, Theano will use
     # a NumPy C implementation of [sd]gemm_.
     if theano.config.cxx == "" or node.inputs[0].dtype == "float16":
@@ -137,7 +137,7 @@ def local_abstractconv3d_gemm(node):
 
 
 @local_optimizer([AbstractConv2d_gradWeights])
-def local_abstractconv_gradweight_gemm(node):
+def local_abstractconv_gradweight_gemm(fgraph, node):
     # If theano.config.blas.ldflags is empty, Theano will use
     # a NumPy C implementation of [sd]gemm_.
     if theano.config.cxx == "" or node.inputs[0].dtype == "float16":
@@ -168,7 +168,7 @@ def local_abstractconv_gradweight_gemm(node):
 
 
 @local_optimizer([AbstractConv3d_gradWeights])
-def local_abstractconv3d_gradweight_gemm(node):
+def local_abstractconv3d_gradweight_gemm(fgraph, node):
     # If theano.config.blas.ldflags is empty, Theano will use
     # a NumPy C implementation of [sd]gemm_.
     if theano.config.cxx == "" or node.inputs[0].dtype == "float16":
@@ -197,7 +197,7 @@ def local_abstractconv3d_gradweight_gemm(node):
 
 
 @local_optimizer([AbstractConv2d_gradInputs])
-def local_abstractconv_gradinputs_gemm(node):
+def local_abstractconv_gradinputs_gemm(fgraph, node):
     # If theano.config.blas.ldflags is empty, Theano will use
     # a NumPy C implementation of [sd]gemm_.
     if theano.config.cxx == "" or node.inputs[0].dtype == "float16":
@@ -227,7 +227,7 @@ def local_abstractconv_gradinputs_gemm(node):
 
 
 @local_optimizer([AbstractConv3d_gradInputs])
-def local_abstractconv3d_gradinputs_gemm(node):
+def local_abstractconv3d_gradinputs_gemm(fgraph, node):
     # If theano.config.blas.ldflags is empty, Theano will use
     # a NumPy C implementation of [sd]gemm_.
     if theano.config.cxx == "" or node.inputs[0].dtype == "float16":
@@ -255,7 +255,7 @@ def local_abstractconv3d_gradinputs_gemm(node):
 
 
 @local_optimizer([AbstractConv2d])
-def local_conv2d_cpu(node):
+def local_conv2d_cpu(fgraph, node):
 
     if not isinstance(node.op, AbstractConv2d) or node.inputs[0].dtype == "float16":
         return None
@@ -287,7 +287,7 @@ def local_conv2d_cpu(node):
 
 
 @local_optimizer([AbstractConv2d_gradWeights])
-def local_conv2d_gradweight_cpu(node):
+def local_conv2d_gradweight_cpu(fgraph, node):
     if (
         not isinstance(node.op, AbstractConv2d_gradWeights)
         or node.inputs[0].dtype == "float16"
@@ -398,7 +398,7 @@ def local_conv2d_gradweight_cpu(node):
 
 
 @local_optimizer([AbstractConv2d_gradInputs])
-def local_conv2d_gradinputs_cpu(node):
+def local_conv2d_gradinputs_cpu(fgraph, node):
     if (
         not isinstance(node.op, AbstractConv2d_gradInputs)
         or node.inputs[0].dtype == "float16"
@@ -574,7 +574,7 @@ conv_groupopt.register(
         AbstractConv3d_gradInputs,
     ]
 )
-def local_abstractconv_check(node):
+def local_abstractconv_check(fgraph, node):
     if isinstance(
         node.op,
         (

--- a/theano/tensor/nnet/sigm.py
+++ b/theano/tensor/nnet/sigm.py
@@ -274,7 +274,7 @@ pprint.assign(ultra_fast_sigmoid, printing.FunctionPrinter("ultra_fast_sigmoid")
 
 # @opt.register_uncanonicalize
 @gof.local_optimizer([sigmoid])
-def local_ultra_fast_sigmoid(node):
+def local_ultra_fast_sigmoid(fgraph, node):
     """
     When enabled, change all sigmoid to ultra_fast_sigmoid.
 
@@ -329,7 +329,7 @@ def hard_sigmoid(x):
 
 # @opt.register_uncanonicalize
 @gof.local_optimizer([sigmoid])
-def local_hard_sigmoid(node):
+def local_hard_sigmoid(fgraph, node):
     if isinstance(node.op, tensor.Elemwise) and node.op.scalar_op == scalar_sigmoid:
         out = hard_sigmoid(node.inputs[0])
         copy_stack_trace(node.outputs[0], out)
@@ -631,7 +631,7 @@ def is_neg(var):
 
 @opt.register_stabilize
 @gof.local_optimizer([tensor.true_div])
-def local_exp_over_1_plus_exp(node):
+def local_exp_over_1_plus_exp(fgraph, node):
     """
     exp(x)/(1+exp(x)) -> sigm(x)
     c/(1+exp(x)) -> c*sigm(-x)
@@ -982,7 +982,7 @@ def perform_sigm_times_exp(
 
 @opt.register_stabilize
 @gof.local_optimizer([tensor.mul])
-def local_sigm_times_exp(node):
+def local_sigm_times_exp(fgraph, node):
     """
     exp(x) * sigm(-x) -> sigm(x)
     exp(-x) * sigm(x) -> sigm(-x)
@@ -1011,7 +1011,7 @@ def local_sigm_times_exp(node):
 
 @opt.register_stabilize
 @gof.local_optimizer([tensor.inv])
-def local_inv_1_plus_exp(node):
+def local_inv_1_plus_exp(fgraph, node):
     """
     1/(1+exp(x)) -> sigm(-x)
 
@@ -1044,7 +1044,7 @@ def local_inv_1_plus_exp(node):
 
 
 @gof.local_optimizer([tensor.sub])
-def local_1msigmoid(node):
+def local_1msigmoid(fgraph, node):
     """
     1-sigm(x) -> sigm(-x)
 

--- a/theano/tensor/nnet/sigm.py
+++ b/theano/tensor/nnet/sigm.py
@@ -1051,7 +1051,7 @@ def local_1msigmoid(fgraph, node):
     """
     if node.op == tensor.sub:
         sub_l, sub_r = node.inputs
-        if len(sub_r.clients) > 1:
+        if len(fgraph.clients[sub_r]) > 1:
             return  # graph is using both sigm and 1-sigm
         if sub_r.owner and sub_r.owner.op == sigmoid:
             try:

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -33,7 +33,7 @@ from theano.gof import (
 )
 from theano.gof.op import Op
 from theano.gof.opt import (
-    Optimizer,
+    GlobalOptimizer,
     copy_stack_trace,
     in2out,
     local_optimizer,
@@ -214,7 +214,7 @@ def broadcast_like(value, template, fgraph, dtype=None):
     return rval
 
 
-class InplaceElemwiseOptimizer(Optimizer):
+class InplaceElemwiseOptimizer(GlobalOptimizer):
     """
     We parametrise it to make it work for Elemwise and GpuElemwise op.
     """
@@ -1664,7 +1664,7 @@ class ShapeFeature:
         return True
 
 
-class ShapeOptimizer(Optimizer):
+class ShapeOptimizer(GlobalOptimizer):
     """Optimizer that serves to add ShapeFeature as an fgraph feature."""
 
     def add_requirements(self, fgraph):
@@ -1674,7 +1674,7 @@ class ShapeOptimizer(Optimizer):
         pass
 
 
-class UnShapeOptimizer(Optimizer):
+class UnShapeOptimizer(GlobalOptimizer):
     """Optimizer remove ShapeFeature as an fgraph feature."""
 
     def apply(self, fgraph):
@@ -7729,11 +7729,11 @@ def elemwise_max_input_fct(node):
 local_elemwise_fusion = local_elemwise_fusion_op(Elemwise, elemwise_max_input_fct)
 
 
-class FusionOptimizer(Optimizer):
+class FusionOptimizer(GlobalOptimizer):
     """Graph optimizer for Fusion of elemwise operations."""
 
     def __init__(self, local_optimizer):
-        Optimizer.__init__(self)
+        super().__init__()
         self.optimizer = local_optimizer
 
     def add_requirements(self, fgraph):

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -982,7 +982,7 @@ class MakeVectorPrinter:
 tt.pprint.assign(MakeVector, MakeVectorPrinter())
 
 
-class ShapeFeature:
+class ShapeFeature(toolbox.Feature):
     """Graph optimizer for removing all calls to shape().
 
     This optimizer replaces all Shapes and Subtensors of Shapes with

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -1455,10 +1455,6 @@ class ShapeFeature:
     def make_vector_shape(self, r):
         return make_vector(*self.shape_of[r])
 
-    #
-    # Feature interface
-    #
-    #
     def on_attach(self, fgraph):
         assert not hasattr(fgraph, "shape_feature")
         fgraph.shape_feature = self

--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -52,12 +52,12 @@ def local_max_and_argmax(fgraph, node):
     """
     if isinstance(node.op, tt.MaxAndArgmax):
         axis = node.op.get_params(node)
-        if len(node.outputs[1].clients) == 0:
+        if len(fgraph.clients[node.outputs[1]]) == 0:
             new = tt.Max(axis)(node.inputs[0])
             copy_stack_trace(node.outputs[0], new)
             return [new, None]
 
-        if len(node.outputs[0].clients) == 0:
+        if len(fgraph.clients[node.outputs[0]]) == 0:
             new = tt.Argmax(axis)(node.inputs[0])
             copy_stack_trace(node.outputs[0], new)
             return [None, new]

--- a/theano/tensor/opt_uncanonicalize.py
+++ b/theano/tensor/opt_uncanonicalize.py
@@ -46,7 +46,7 @@ _logger = logging.getLogger("theano.tensor.opt")
 
 @register_uncanonicalize
 @local_optimizer([tt.MaxAndArgmax])
-def local_max_and_argmax(node):
+def local_max_and_argmax(fgraph, node):
     """
     If we don't use the argmax, change it to a max only.
     """
@@ -65,7 +65,7 @@ def local_max_and_argmax(node):
 
 @register_uncanonicalize
 @local_optimizer([tt.neg])
-def local_max_to_min(node):
+def local_max_to_min(fgraph, node):
     """
     Change -(max(-x)) to min.
 
@@ -94,7 +94,7 @@ def local_max_to_min(node):
 
 @register_uncanonicalize
 @local_optimizer([tt.Alloc])
-def local_alloc_dimshuffle(node):
+def local_alloc_dimshuffle(fgraph, node):
     """
     If a dimshuffle is inside an alloc and only adds dimension to the
     left, remove it.
@@ -117,7 +117,7 @@ def local_alloc_dimshuffle(node):
 
 @register_uncanonicalize
 @local_optimizer([tt.Reshape])
-def local_reshape_dimshuffle(node):
+def local_reshape_dimshuffle(fgraph, node):
     """
     If a dimshuffle is inside a reshape and does not change the order
     of dimensions, remove it.
@@ -146,7 +146,7 @@ def local_reshape_dimshuffle(node):
 
 @register_uncanonicalize
 @local_optimizer([DimShuffle])
-def local_dimshuffle_alloc(node):
+def local_dimshuffle_alloc(fgraph, node):
     """
     If an alloc is inside a dimshuffle which only adds dimension to the left,
     scrap the dimshuffle and adds 1 into the alloc
@@ -174,7 +174,7 @@ def local_dimshuffle_alloc(node):
 
 @register_uncanonicalize
 @local_optimizer([DimShuffle])
-def local_dimshuffle_subtensor(node):
+def local_dimshuffle_subtensor(fgraph, node):
     """If a subtensor is inside a dimshuffle which only drop
     broadcastable dimensions, scrap the dimshuffle and index the
     subtensor with 0

--- a/theano/tensor/raw_random.py
+++ b/theano/tensor/raw_random.py
@@ -930,7 +930,7 @@ def multinomial(random_state, size=None, n=1, pvals=None, ndim=None, dtype="int6
 
 
 @gof.local_optimizer([RandomFunction])
-def random_make_inplace(node):
+def random_make_inplace(fgraph, node):
     op = node.op
     if isinstance(op, RandomFunction) and not op.inplace:
         # Read op_fn from op.state, not from op.fn, since op.fn

--- a/theano/tensor/raw_random.py
+++ b/theano/tensor/raw_random.py
@@ -214,7 +214,7 @@ class RandomFunction(gof.Op):
 
         return gof.Apply(self, [r, shape] + args, [r.type(), self.outtype()])
 
-    def infer_shape(self, node, i_shapes):
+    def infer_shape(self, fgraph, node, i_shapes):
         r, shp = node.inputs[0:2]
 
         # if shp is a constant array of len 0, then it means 'automatic shape'

--- a/theano/tensor/signal/pool.py
+++ b/theano/tensor/signal/pool.py
@@ -600,7 +600,7 @@ class Pool(OpenMPOp):
             for r in np.ndindex(*pool_out_shp):
                 zzk[r] = func(yk[[region_slices[i][r[i]] for i in range(nd)]])
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         ws, stride, pad = [node.inputs[1], node.inputs[2], node.inputs[3]]
         shp = self.out_shape(
             in_shapes[0], ws, self.ignore_border, stride, pad, self.ndim
@@ -1151,7 +1151,7 @@ class PoolGrad(OpenMPOp):
                 storage_map[pad] = [None]
                 compute_map[pad] = [False]
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         return [in_shapes[0]]
 
 
@@ -1927,7 +1927,7 @@ class DownsampleFactorMaxGradGrad(OpenMPOp):
                     if maxout_value == yk[c]:
                         ggzk[r] += ggxk[c]
 
-    def infer_shape(self, node, in_shapes):
+    def infer_shape(self, fgraph, node, in_shapes):
         return [in_shapes[1]]
 
     def grad(self, inp, grads):

--- a/theano/tensor/slinalg.py
+++ b/theano/tensor/slinalg.py
@@ -62,7 +62,7 @@ class Cholesky(Op):
             raise ValueError('on_error must be one of "raise" or ""nan"')
         self.on_error = on_error
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
     def make_node(self, x):
@@ -203,7 +203,7 @@ class CholeskyGrad(Op):
                 F[k, k] /= 2 * L[k, k]
         dx[0] = F
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -255,7 +255,7 @@ class Solve(Op):
         output_storage[0][0] = rval
 
     # computes shape of x where x = inv(A) * b
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         Ashape, Bshape = shapes
         rows = Ashape[1]
         if len(Bshape) == 1:  # b is a Vector
@@ -376,7 +376,7 @@ class Eigvalsh(Op):
         (gw,) = g_outputs
         return EigvalshGrad(self.lower)(a, b, gw)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         n = shapes[0][0]
         return [(n,)]
 
@@ -436,7 +436,7 @@ class EigvalshGrad(Op):
         outputs[0][0] = np.asarray(out1, dtype=node.outputs[0].dtype)
         outputs[1][0] = np.asarray(out2, dtype=node.outputs[1].dtype)
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0], shapes[1]]
 
 
@@ -520,7 +520,7 @@ class Expm(Op):
         (g_out,) = outputs
         return [ExpmGrad()(A, g_out)]
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
 
@@ -545,7 +545,7 @@ class ExpmGrad(Op):
             ],
         )
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
     def perform(self, node, inputs, outputs):

--- a/theano/tensor/sort.py
+++ b/theano/tensor/sort.py
@@ -51,7 +51,7 @@ class SortOp(Op):
         z = output_storage[0]
         z[0] = np.sort(a, axis, self.kind, self.order)
 
-    def infer_shape(self, node, inputs_shapes):
+    def infer_shape(self, fgraph, node, inputs_shapes):
         if _variable_is_none(node.inputs[1]):
             # That means axis = None,
             # So the array is flattened before being sorted
@@ -192,7 +192,7 @@ class ArgSortOp(Op):
             np.argsort(a, axis, self.kind, self.order), dtype=node.outputs[0].dtype
         )
 
-    def infer_shape(self, node, inputs_shapes):
+    def infer_shape(self, fgraph, node, inputs_shapes):
         if _variable_is_none(node.inputs[1]):
             return [(mul(*inputs_shapes[0]),)]
         # axis should not be None, so there should be the same number of
@@ -437,7 +437,7 @@ class TopKOp(Op):
             pzi = output_storage[0]
             pzi[0] = _topk_py_impl(self, x, k, axis, node.outputs[0].dtype)
 
-    def infer_shape(self, node, inp_shapes):
+    def infer_shape(self, fgraph, node, inp_shapes):
         shp = list(inp_shapes[0])
         shp[self.axis] = np.abs(node.inputs[1])
         shp = tuple(shp)

--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -683,7 +683,7 @@ class Subtensor(Op):
 
         out[0] = np.asarray(x.__getitem__(cdata))
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         xshp = shapes[0]
         assert len(xshp) == node.inputs[0].ndim
         outshp = []
@@ -1769,7 +1769,7 @@ class IncSubtensor(Op):
             % locals()
         )
 
-    def infer_shape(self, node, shapes):
+    def infer_shape(self, fgraph, node, shapes):
         return [shapes[0]]
 
     def R_op(self, inputs, eval_points):
@@ -1946,7 +1946,7 @@ class AdvancedSubtensor1(Op):
             return [None]
         return self.make_node(eval_points[0], *inputs[1:]).outputs
 
-    def infer_shape(self, node, ishapes):
+    def infer_shape(self, fgraph, node, ishapes):
         x, ilist = ishapes
         return [ilist + x[1:]]
 
@@ -2202,7 +2202,7 @@ class AdvancedIncSubtensor1(Op):
 
         out[0] = x
 
-    def infer_shape(self, node, ishapes):
+    def infer_shape(self, fgraph, node, ishapes):
         x, y, ilist = ishapes
         return [x]
 
@@ -2332,7 +2332,7 @@ class AdvancedSubtensor(Op):
             return [None]
         return self.make_node(eval_points[0], *inputs[1:]).outputs
 
-    def infer_shape(self, node, ishapes):
+    def infer_shape(self, fgraph, node, ishapes):
         indices = node.inputs[1:]
         index_shapes = list(ishapes[1:])
         for i, idx in enumerate(indices):
@@ -2451,7 +2451,7 @@ class AdvancedIncSubtensor(Op):
         else:
             np.add.at(out[0], tuple(inputs[2:]), inputs[1])
 
-    def infer_shape(self, node, ishapes):
+    def infer_shape(self, fgraph, node, ishapes):
         return [ishapes[0]]
 
     def connection_pattern(self, node):

--- a/theano/typed_list/opt.py
+++ b/theano/typed_list/opt.py
@@ -4,7 +4,7 @@ from theano.typed_list.basic import Append, Extend, Insert, Remove, Reverse
 
 
 @gof.local_optimizer([Append, Extend, Insert, Reverse, Remove], inplace=True)
-def typed_list_inplace_opt(node):
+def typed_list_inplace_opt(fgraph, node):
     if (
         isinstance(node.op, (Append, Extend, Insert, Reverse, Remove))
         and not node.op.inplace


### PR DESCRIPTION
This PR introduces some major refactoring of the optimizers classes.  Its main goal is to remove the inconsistent graph-specific information from `Variable` instances and put the burden of determining a `Variable`s clients on the `FunctionGraph` object.  `FunctionGraph`s are specifically designed for the purpose of holding useful information about a specific graph, so the task of tracking client mappings (i.e. which terms depend on a given `Variable`) falls squarely within its scope.

In other words, this PR removes the ephemeral fields `Variable.clients` and `Variable.fgraph` and changes the signature of `LocalOptimizer.transform` to include an `fgraph` argument from which one can obtain the clients via `fgraph.clients[v]` for some `Variable` `v`.

With these changes, applying transforms/optimizations will be considerably easier since we'll no longer face "Variable already owned by a different fgraph" errors.  In general, we will have removed the main source of unnecessary and complicated side effects due to graph optimization.  This should also pave the way for copy-free optimization (i.e. we won't need to completely copy/clone a graph in order to optimize it).

- [x] Add `fgraph` argument to `LocalOptimizer` methods
- [x] Replace `Variable.clients` with `FunctionGraph.clients`
- [x] Remove `Variable.fgraph`

Closes #100.