### PR TITLE
Avoid Elemwise fusion for scalar Ops without C implementations

### DIFF
--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -7697,6 +7697,7 @@ your code will run correctly, but may be slower."""
                     "loop fusion."
                 )
             )
+            return False
 
         # create the composite op.
         composite_op = ts.Composite(s_inputs, s_new_out)

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -7624,11 +7624,10 @@ def local_elemwise_fusion_op(op_class, max_input_fct=lambda node: 32, maker=None
                 except (NotImplementedError, MethodNotDefined):
                     _logger.warning(
                         (
-                            "%s does not implement the c_code function."
-                            " As well as being potentially slow, this"
-                            " disables loop fusion of this op."
+                            f"The Op {i.owner.op.scalar_op} does not provide a C implementation."
+                            " As well as being potentially slow, this also disables "
+                            "loop fusion."
                         )
-                        % str(i.owner.op.scalar_op)
                     )
                     do_fusion = False
 
@@ -7693,11 +7692,10 @@ your code will run correctly, but may be slower."""
         except (NotImplementedError, MethodNotDefined):
             _logger.warning(
                 (
-                    "%s does not implement the c_code function."
-                    " As well as being potentially slow, this disables "
-                    "loop fusion of this op."
+                    f"The Op {s_new_out[0].owner.op} does not provide a C implementation."
+                    " As well as being potentially slow, this also disables "
+                    "loop fusion."
                 )
-                % str(s_new_out[0].owner.op)
             )
 
         # create the composite op.


### PR DESCRIPTION
This PR fixes an issue involving the fusion of `Elemwise` `Op`s with scalar `Op`s that do not have `Op.c_code` implementations.

There were no *direct* tests for the relevant condition in `local_elemwise_fusion_op` (i.e. the `return` missing from within [here](https://github.com/pymc-devs/Theano-PyMC/blob/0150ddf616353b14a72159b5ac4e7e9f34c03f24/theano/tensor/opt.py#L7694)), so, naturally, this issue went unnoticed.  It's possible&mdash;albeit doubtful&mdash;that there were even any _indirect_ tests for this (whether intentional or not).  

This is yet another great example of how badly we need to refactor the tests (e.g. #141, #23, etc.) and dramatically change the testing standards.  For example, the test added in this PR creates [its own `Op`](https://github.com/pymc-devs/Theano-PyMC/blob/7a55dade02648b27ef5d73fffef08ba45107d62c/tests/tensor/test_opt.py#L2101) that lacks a `c_code` method; had we used an existing `Op` that lacked a `c_code` method (e.g. `theano.tensor.basic.i0`) we would've implicitly added an unnecessary testing dependency/requirement, and, in the somewhat likely event that a `c_code` implementation is given to said `Op`, the entire test would've been silently invalidated.  
Likewise, the same test attempts to force C compilation and explicitly includes the relevant optimizations; however, many tests in that module simply assume that the optimizations they're testing are enabled in the default mode object (e.g. `mode_opt` in `tests.tensor.test_opt`).  This approach is confounded by all the other optimizations enabled in the default/global mode, and it makes all the tests that rely on it brittle and highly dependent on those other unrelated optimizations.

Closes #160.