### PR TITLE
Return the correct output for multi-output inputs in a JAXified graph

### DIFF
--- a/tests/sandbox/test_jax.py
+++ b/tests/sandbox/test_jax.py
@@ -281,6 +281,14 @@ def test_jax_basic_multiout():
     out_fg = theano.gof.FunctionGraph([x], outs)
     compare_jax_and_py(out_fg, [X.astype(tt.config.floatX)], assert_fn=assert_fn)
 
+    # Test that a single output of a multi-output `Op` can be used as input to
+    # another `Op`
+    x = tt.dvector()
+    mx, amx = theano.tensor.MaxAndArgmax([0])(x)
+    out = mx * amx
+    out_fg = theano.gof.FunctionGraph([x], [out])
+    compare_jax_and_py(out_fg, [np.r_[1, 2]])
+
 
 @pytest.mark.skip(reason="Not fully implemented, yet.")
 def test_jax_scan():


### PR DESCRIPTION
This PR provides a fix for the case in which an intermediate graph input is one of multiple `Op` outputs in a JAX-ified graph.

Closes #165.