### PR TITLE
Update conda CI steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v2
         with:
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
           python-version: ${{ matrix.python-version }}
           auto-update-conda: true
 
@@ -125,10 +128,10 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install --yes -q mkl numpy scipy pip mkl-service graphviz cython libgpuarray pygpu
-          if [[ "$PYTHON_VERSION" != "3.6" ]]; then conda install --yes -q -c conda-forge jax jaxlib; fi
+          mamba install --yes -q mkl numpy scipy pip mkl-service graphviz cython libgpuarray pygpu
+          if [[ "$PYTHON_VERSION" != "3.6" ]]; then mamba install --yes -q -c conda-forge jax jaxlib; fi
           pip install -q -r requirements.txt
-          conda list && pip freeze
+          mamba list && pip freeze
           python -c 'import theano; print(theano.config.__str__(print_doc=False))'
           python -c 'import theano; assert(theano.config.blas.ldflags != "")'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: true


### PR DESCRIPTION
This PR fixes the current CI issues involving our use of a deprecated `setup-miniconda` action.  It also changes our CI steps so that they use the faster `mamba` instead of `conda`.