### PR TITLE
Add notebooks directory for Sandbox, Development and Example notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,9 @@ Theano.suo
 .ropeproject
 core
 .idea
+.vs
 .mypy_cache/
 /htmlcov/
 
 theano-venv/
+/notebooks/Sandbox*

--- a/notebooks/Dev_ClassGraph.ipynb
+++ b/notebooks/Dev_ClassGraph.ipynb
@@ -1,0 +1,4765 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Development Notebook: Visualization of Class Hierarchies\n",
+    "This notebook was added to facilitate development & refactoring of the code base."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:100% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.core.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipycytoscape\n",
+    "import networkx\n",
+    "import inspect\n",
+    "import theano\n",
+    "import theano.tensor as tt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "modules = [\n",
+    "    # specify which modules to search:\n",
+    "    theano,\n",
+    "    tt\n",
+    "]\n",
+    "\n",
+    "# lookup for module-wise colors\n",
+    "# TODO: use shades of the parent color for sub-sub-modules\n",
+    "COLORS = {\n",
+    "    'theano.compile.function.pfunc': \"red\",\n",
+    "    'theano.compile.function.types': \"red\",\n",
+    "    'theano.compile.io': \"red\",\n",
+    "    'theano.compile.mode': \"red\",\n",
+    "    'theano.compile.ops': \"red\",\n",
+    "    'theano.compile.profiling': \"red\",\n",
+    "    'theano.configparser': \"purple\",\n",
+    "    'theano.gof.cc': \"yellow\",\n",
+    "    'theano.gof.fg': \"yellow\",\n",
+    "    'theano.gof.graph': \"yellow\",\n",
+    "    'theano.gof.link': \"yellow\",\n",
+    "    'theano.gof.op': \"yellow\",\n",
+    "    'theano.gof.params_type': \"yellow\",\n",
+    "    'theano.gof.type': \"yellow\",\n",
+    "    'theano.gof.utils': \"yellow\",\n",
+    "    'theano.gradient': \"green\",\n",
+    "    'theano.tensor.basic': \"blue\",\n",
+    "    'theano.tensor.elemwise': \"blue\",\n",
+    "    'theano.tensor.extra_ops': \"blue\",\n",
+    "    'theano.tensor.io': \"blue\",\n",
+    "    'theano.tensor.subtensor': \"blue\",\n",
+    "    'theano.tensor.type': \"blue\",\n",
+    "    'theano.tensor.type_other': \"blue\",\n",
+    "    'theano.tensor.var': \"blue\",\n",
+    "    'theano.updates': \"orange\",\n",
+    "}\n",
+    "\n",
+    "# build a dictionary of all classes in the specified modules\n",
+    "classes = {}\n",
+    "for module in modules:\n",
+    "    for name, mem in inspect.getmembers(module):\n",
+    "        if inspect.isclass(mem):\n",
+    "            classes[name] = mem\n",
+    "            if not mem.__module__ in COLORS:\n",
+    "                COLORS[mem.__module__] = \"pink\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# helper functions for creating a NetworkX \n",
+    "def add_or_create(G, cls):\n",
+    "    name = cls.__name__\n",
+    "    if name in G:\n",
+    "        return\n",
+    "    color = COLORS.get(cls.__module__, \"pink\")\n",
+    "    G.add_node(name, name=name, label=name, color=color, tooltip=str(cls.__module__))\n",
+    "    for superclass in cls.__mro__[1:2]:\n",
+    "        add_or_create(G, superclass)\n",
+    "        G.add_edge(superclass.__name__, name)\n",
+    "\n",
+    "def make_graph(classes):\n",
+    "    G = networkx.DiGraph()\n",
+    "    for name, cls in classes.items():\n",
+    "        add_or_create(G, cls)\n",
+    "    return G    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5a9c0fbf9bcf4dc99ea6d8afb429ddbc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "CytoscapeWidget(cytoscape_layout={'name': 'dagre', 'rankDir': 'LR', 'nodeDimensionsIncludeLabels': True, 'spac…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "G = make_graph(classes)\n",
+    "cso = ipycytoscape.CytoscapeWidget(height=500)\n",
+    "cso.graph.add_graph_from_networkx(G, directed=True)\n",
+    "cso.set_style([\n",
+    "    {\n",
+    "        'selector': 'node',\n",
+    "        'css': {\n",
+    "            #'background-color': '#9dbaea',\n",
+    "            'background-color': 'data(color)',\n",
+    "            'content': 'data(name)',\n",
+    "            'text-valign': 'center',\n",
+    "            'font-size': 10,\n",
+    "            #'color': 'white',\n",
+    "            #'text-outline-width': 2,\n",
+    "            #'text-outline-color': 'green',\n",
+    "            #'background-color': 'green'\n",
+    "        }\n",
+    "    },\n",
+    "    {'selector': 'node:parent', 'css': {'background-opacity': 0.333}},\n",
+    "    {\n",
+    "        'selector': ':selected',\n",
+    "        'css': {\n",
+    "            'background-color': 'black',\n",
+    "            'line-color': 'black',\n",
+    "            'target-arrow-color': 'black',\n",
+    "            'source-arrow-color': 'black',\n",
+    "            'text-outline-color': 'black'\n",
+    "        }\n",
+    "    },\n",
+    "    {'selector': 'edge', 'style': {'width': 2, 'line-color': '#11479e'}},\n",
+    "    {\n",
+    "        'selector': 'edge.directed',\n",
+    "        'style': {\n",
+    "            'curve-style': 'bezier',\n",
+    "            'target-arrow-shape': 'triangle',\n",
+    "            'target-arrow-color': '#11479e'\n",
+    "        }\n",
+    "    },\n",
+    "    {'selector': 'edge.multiple_edges', 'style': {'curve-style': 'bezier'}}\n",
+    "])\n",
+    "cso.layout.height = '1200px'\n",
+    "cso.set_layout(name=\"dagre\", rankDir=\"LR\", nodeDimensionsIncludeLabels=True, spacingFactor=0.7)\n",
+    "cso"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "002d6da2e6fe4cb3925e3889b33129cf": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "a176e649-bda0-41f8-a4fe-208c97cd5ccf",
+        "source": "Op",
+        "target": "SpecifyShape"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "0388b8b29c34472996cc4cdb6407b049": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "e683139d-41c4-4696-8874-a9fa4001590d",
+        "source": "Exception",
+        "target": "ShapeError"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "0999a7817f9943ffb8dc09adbc50d7ec": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "3a580d50-abea-4808-9906-bb5d20084fb2",
+        "source": "Op",
+        "target": "Subtensor"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "0a8c035be3cb43ee90bc471e30ded51d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Flatten",
+        "label": "Flatten",
+        "name": "Flatten",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2281.25
+       }
+      }
+     },
+     "0a9879ad64054a099950c9bf4304a7fc": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "65e56212-0624-4487-82ae-d13ba406868a",
+        "source": "Type",
+        "target": "ParamsType"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "0c9f9f3f606b4304b79f1534380d217d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Eye",
+        "label": "Eye",
+        "name": "Eye",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2223.85
+       }
+      }
+     },
+     "0d7745d27dff41e383ecb3da0f739140": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "5981cf07-940f-4b8b-92a0-54bf93c28328",
+        "source": "object",
+        "target": "Linker"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "0f3793e67c574ae6b16d99f0ea76c654": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "ad227f90-1e0f-4976-9012-3f5a6579f6b8",
+        "source": "_tensor_py_operators",
+        "target": "TensorConstant"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "105d941de88e40b2952c28a5e4564bd2": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Nonzero",
+        "label": "Nonzero",
+        "name": "Nonzero",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2855.25
+       }
+      }
+     },
+     "1714002d62074ab187c1630ef9bff6cf": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "_tensor_py_operators",
+        "label": "_tensor_py_operators",
+        "name": "_tensor_py_operators",
+        "tooltip": "theano.tensor.var"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4347.65
+       }
+      }
+     },
+     "18a7eb283b9549db8df3539b5e847cef": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Node",
+        "label": "Node",
+        "name": "Node",
+        "tooltip": "theano.gof.graph"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 846.2500000000002
+       }
+      }
+     },
+     "1b18dd448439490b93652283173adce2": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "InconsistencyError",
+        "label": "InconsistencyError",
+        "name": "InconsistencyError",
+        "tooltip": "theano.gof.fg"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3716.25
+       }
+      }
+     },
+     "1b2b88c4566d4099ab0936a5d369b7da": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "1200px"
+      }
+     },
+     "1b3efa11ba6d4b80b2c1d2345e8752e8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "8d3aaf37-e6e0-4737-9431-b98ee2f0366f",
+        "source": "Op",
+        "target": "Dot"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "1ca7a7bbe6314bb2ba2df5c065fb3de3": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Linker",
+        "label": "Linker",
+        "name": "Linker",
+        "tooltip": "theano.gof.link"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 3429.25
+       }
+      }
+     },
+     "1cbf9bc46ad1449bbdf21ff4c3263450": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "114ca966-8532-4f32-8be4-7ea63ceed01c",
+        "source": "Op",
+        "target": "IncSubtensor"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "1d62ad221ed1429fa940456a7c54affc": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Variable",
+        "label": "Variable",
+        "name": "Variable",
+        "tooltip": "theano.gof.graph"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 903.6500000000001
+       }
+      }
+     },
+     "1f8f919bae5744fbbf36734a31908659": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "89f33fc2-b884-4300-8e14-23c0ca714459",
+        "source": "Exception",
+        "target": "TypeError"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "1fa67f7ab2b140969b119bc0b1d472ff": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "purple",
+        "id": "change_flags",
+        "label": "change_flags",
+        "name": "change_flags",
+        "tooltip": "theano.configparser"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4175.45
+       }
+      }
+     },
+     "1ff84084f0b0477985fa12e6f91600ec": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "AdvancedSubtensor1",
+        "label": "AdvancedSubtensor1",
+        "name": "AdvancedSubtensor1",
+        "tooltip": "theano.tensor.subtensor"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1535.0500000000002
+       }
+      }
+     },
+     "201dd4bc7cae4b2e8306036ecbd381c2": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "6d45730a-5ccd-49b4-9b72-cdb2820f3356",
+        "source": "LocalLinker",
+        "target": "OpWiseCLinker"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "213318f3378145c68d2516a214761f53": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "0ce0c83a-c247-4bd1-be2c-37cacef6ef1c",
+        "source": "object",
+        "target": "SymbolicOutput"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "2340c07adc6044768bbe6b9e4baeec6d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "f0bba555-fcbe-401b-a20f-c95809ff0eec",
+        "source": "Op",
+        "target": "Alloc"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "27ff6520d333492ba76fc1c8b4c8f880": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "NoneTypeT",
+        "label": "NoneTypeT",
+        "name": "NoneTypeT",
+        "tooltip": "theano.tensor.type_other"
+       },
+       "position": {
+        "x": 624.175,
+        "y": 961.0500000000002
+       }
+      }
+     },
+     "2904b28264514b6198f00ef1b222b39b": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "19ffea0d-e00d-4cf5-91d6-cd3eb2a73e93",
+        "source": "object",
+        "target": "SymbolicInput"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "297cd1cb263a4ad0b2321e384ed2d8b7": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "b664991a-a2ad-4e82-8fc3-acd26dcc075b",
+        "source": "Exception",
+        "target": "MethodNotDefined"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "2ca85c74202d428b9c8a18081e980267": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "Exception",
+        "label": "Exception",
+        "name": "Exception",
+        "tooltip": "builtins"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 3831.05
+       }
+      }
+     },
+     "2e4beb5a3ef345c28e4fa60295dd4db5": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "0418a1a0-544f-48a3-9aae-07d67ac67240",
+        "source": "Type",
+        "target": "TensorType"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "3135f96b0c574e9d8841c33c9263b6c6": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "44ace864-aef4-45f7-8027-b8a281be87ad",
+        "source": "Op",
+        "target": "AdvancedSubtensor"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "33e168a3f9074518be942c01863d3551": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "a3c6998f-20f8-4b58-870f-eb891508f3c2",
+        "source": "CAReduce",
+        "target": "CAReduceDtype"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "35cb6efbe0894682aa751e3090db3fb8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "50d79af3-f024-4d98-9e79-eeb167350a65",
+        "source": "Op",
+        "target": "Tri"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "35d25408d0874a9db36b0a170e549203": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "MPISendWait",
+        "label": "MPISendWait",
+        "name": "MPISendWait",
+        "tooltip": "theano.tensor.io"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2683.05
+       }
+      }
+     },
+     "36bf721b1daf4a03a9e5c2ae770da8b7": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Subtensor",
+        "label": "Subtensor",
+        "name": "Subtensor",
+        "tooltip": "theano.tensor.subtensor"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3314.45
+       }
+      }
+     },
+     "376b7ad031184a71aedb281351713756": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "Shape",
+        "label": "Shape",
+        "name": "Shape",
+        "tooltip": "theano.compile.ops"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3142.25
+       }
+      }
+     },
+     "392e40ee037041f58fde00e9d00abcbe": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "580f3e58-13ac-483d-8496-c1dcb8d1f795",
+        "source": "object",
+        "target": "partial"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "3b0145e58db14f759bacff4f3922f7e8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Generic",
+        "label": "Generic",
+        "name": "Generic",
+        "tooltip": "theano.gof.type"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 961.0500000000002
+       }
+      }
+     },
+     "3d38d2af0f87432f987ab52d1598da55": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "TensorVariable",
+        "label": "TensorVariable",
+        "name": "TensorVariable",
+        "tooltip": "theano.tensor.var"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 4376.35
+       }
+      }
+     },
+     "3faca9dc920f4d5c87dea21e47939c3e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "SymbolicOutput",
+        "label": "SymbolicOutput",
+        "name": "SymbolicOutput",
+        "tooltip": "theano.compile.io"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4060.6499999999996
+       }
+      }
+     },
+     "40b0bceafb2448878ce3b6c1bef953d9": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "AdvancedIndexingError",
+        "label": "AdvancedIndexingError",
+        "name": "AdvancedIndexingError",
+        "tooltip": "theano.tensor.subtensor"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 3773.65
+       }
+      }
+     },
+     "437a3da0f49a4042a8def494764130d5": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "e611dd46-583d-4bd6-a79e-3b75226c82e1",
+        "source": "Op",
+        "target": "Nonzero"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "439d468e187945b59d7f536562ad9342": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "OrderedDict",
+        "label": "OrderedDict",
+        "name": "OrderedDict",
+        "tooltip": "collections"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 4003.25
+       }
+      }
+     },
+     "43c93d8aa9fd4c52a11cbfcf1d1ccf0a": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "SliceType",
+        "label": "SliceType",
+        "name": "SliceType",
+        "tooltip": "theano.tensor.type_other"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1133.25
+       }
+      }
+     },
+     "44c717bbd0e444ed806a84de8caaaf4c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Join",
+        "label": "Join",
+        "name": "Join",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2396.05
+       }
+      }
+     },
+     "45285d5fa8b846418fc1597227b29b6f": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "c53b59e2-6141-439e-bb40-3a4bf9223f8f",
+        "source": "OrderedDict",
+        "target": "OrderedUpdates"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "4582f058ac0b4c4c8f147dd5822d8a19": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "bda9122f-670d-4afe-9af5-1e6f436340a4",
+        "source": "Op",
+        "target": "LoadFromDisk"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "46cdcb19451c44a69b9c4b76b0c32b54": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "05b3efe4-4aa9-44b3-9f79-fcd446916b67",
+        "source": "tuple",
+        "target": "TensorConstantSignature"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "472cec6b1556423facf672a58d572177": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "4699f0ed-ba6d-4721-a466-03716ddfdf2a",
+        "source": "Op",
+        "target": "Eye"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "476b003029da441685039f353ac715bb": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "f39a91b2-eebe-4ad5-98a1-1b552dda9d50",
+        "source": "Exception",
+        "target": "NotScalarConstantError"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "48cfb2b2a4ab411cacd1672e0c0320b7": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "ff5fdf94-0024-490a-8a5f-862bda850cfb",
+        "source": "Linker",
+        "target": "DualLinker"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "4a498380b94c40389e39b8a9b1d79aa4": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "green",
+        "id": "numeric_grad",
+        "label": "numeric_grad",
+        "name": "numeric_grad",
+        "tooltip": "theano.gradient"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4605.95
+       }
+      }
+     },
+     "4ae475a73f9a419395a16520cdaafe68": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "f08f6dfa-10db-404d-9493-af4e192c02ec",
+        "source": "Reversible",
+        "target": "Sequence"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "4b23eea474794b6795a26c95d88079df": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "DimShuffle",
+        "label": "DimShuffle",
+        "name": "DimShuffle",
+        "tooltip": "theano.tensor.elemwise"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 2051.65
+       }
+      }
+     },
+     "4b84d219bb0f4afb9688d95920eb1b22": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "SpecifyShape",
+        "label": "SpecifyShape",
+        "name": "SpecifyShape",
+        "tooltip": "theano.compile.ops"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3199.65
+       }
+      }
+     },
+     "4bc2fe02366e4d9096a261ef8fe33a2a": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "GraphModel",
+      "state": {
+       "_adj": {},
+       "_model_module_version": "^1.0.4",
+       "_view_module": "jupyter-cytoscape",
+       "_view_module_version": "^1.0.4"
+      }
+     },
+     "4c0533b9a7204bada7abff075dd771e8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "33fe3fce-653b-4a0e-90ce-2a54ac0545bf",
+        "source": "Op",
+        "target": "CAReduce"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "4c1cde2663ed4ac2b1c6944666970439": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "349da31e-eb83-4bc6-bd44-eb52c5c211fb",
+        "source": "Op",
+        "target": "Join"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "4c5d8e778e1c42eaafee221a498370a9": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Constant",
+        "label": "Constant",
+        "name": "Constant",
+        "tooltip": "theano.gof.graph"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 903.6500000000001
+       }
+      }
+     },
+     "4d6dc4e13d6e4586a5ac9ff181a48d61": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "MPISend",
+        "label": "MPISend",
+        "name": "MPISend",
+        "tooltip": "theano.tensor.io"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2625.65
+       }
+      }
+     },
+     "4e36066dda37461db7a3d44151557b42": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "f497220c-b20b-4170-8a6d-d8f7bfda7f4f",
+        "source": "object2",
+        "target": "Op"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "4f94e7e7192b43788a33eeee0bdebd6c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Apply",
+        "label": "Apply",
+        "name": "Apply",
+        "tooltip": "theano.gof.graph"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 846.2500000000002
+       }
+      }
+     },
+     "50a68ed55dd94fdca7e6e88ff3ed9819": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "6a6cdf56-72c1-4c35-af3c-c7975bc8a8cd",
+        "source": "object2",
+        "target": "Node"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "51d3afad15fa4c08957b4c0f725daa6f": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "f5dea5f0-a5e4-4123-b369-8882a9c31a91",
+        "source": "object",
+        "target": "Mode"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "52b4cfa7813b46208806a812cf930e52": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Op",
+        "label": "Op",
+        "name": "Op",
+        "tooltip": "theano.gof.op"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 2367.35
+       }
+      }
+     },
+     "52c992870efd43219229c761a4692119": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "orange",
+        "id": "OrderedUpdates",
+        "label": "OrderedUpdates",
+        "name": "OrderedUpdates",
+        "tooltip": "theano.updates"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 4003.25
+       }
+      }
+     },
+     "531de1d3d4614a86a8a4deec43b42694": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "0ceeb9e0-f13b-44af-9c0a-26ce6c3d697e",
+        "source": "BaseException",
+        "target": "Exception"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "53777e18249747318bf7ea8396791c8b": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "TypeError",
+        "label": "TypeError",
+        "name": "TypeError",
+        "tooltip": "builtins"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3773.65
+       }
+      }
+     },
+     "54446d71dd29431585ba6016f59a038a": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "complex",
+        "label": "complex",
+        "name": "complex",
+        "tooltip": "builtins"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4720.75
+       }
+      }
+     },
+     "560c485869ab42a4b628e3007d3f2ea1": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "7888bb8a-3f84-4166-8a59-336242b5a937",
+        "source": "Op",
+        "target": "COp"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "56600419be624fc4ba7ca01740dcba8c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "FunctionGraph",
+        "label": "FunctionGraph",
+        "name": "FunctionGraph",
+        "tooltip": "theano.gof.fg"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 932.3500000000001
+       }
+      }
+     },
+     "56dc29367cfc470ba34aeac170534625": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Tile",
+        "label": "Tile",
+        "name": "Tile",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3429.25
+       }
+      }
+     },
+     "5861dab966bd40df9563ffa73daae29e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "BaseException",
+        "label": "BaseException",
+        "name": "BaseException",
+        "tooltip": "builtins"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 3831.05
+       }
+      }
+     },
+     "5a9c0fbf9bcf4dc99ea6d8afb429ddbc": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "CytoscapeModel",
+      "state": {
+       "_interaction_handlers": {},
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "auto_ungrabify": false,
+       "autolock": false,
+       "cytoscape_layout": {
+        "name": "dagre",
+        "nodeDimensionsIncludeLabels": true,
+        "rankDir": "LR",
+        "spacingFactor": 0.7
+       },
+       "cytoscape_style": [
+        {
+         "css": {
+          "background-color": "data(color)",
+          "content": "data(name)",
+          "font-size": 10,
+          "text-valign": "center"
+         },
+         "selector": "node"
+        },
+        {
+         "css": {
+          "background-opacity": 0.333
+         },
+         "selector": "node:parent"
+        },
+        {
+         "css": {
+          "background-color": "black",
+          "line-color": "black",
+          "source-arrow-color": "black",
+          "target-arrow-color": "black",
+          "text-outline-color": "black"
+         },
+         "selector": ":selected"
+        },
+        {
+         "selector": "edge",
+         "style": {
+          "line-color": "#11479e",
+          "width": 2
+         }
+        },
+        {
+         "selector": "edge.directed",
+         "style": {
+          "curve-style": "bezier",
+          "target-arrow-color": "#11479e",
+          "target-arrow-shape": "triangle"
+         }
+        },
+        {
+         "selector": "edge.multiple_edges",
+         "style": {
+          "curve-style": "bezier"
+         }
+        }
+       ],
+       "desktop_tap_threshold": 4,
+       "graph": "IPY_MODEL_7311e42bdd59408c9a5b4ed1cb738510",
+       "headless": false,
+       "hide_edges_on_viewport": false,
+       "layout": "IPY_MODEL_1b2b88c4566d4099ab0936a5d369b7da",
+       "max_zoom": 1e+50,
+       "min_zoom": 1e-50,
+       "motion_blur": false,
+       "motion_blur_opacity": 0.2,
+       "panning_enabled": true,
+       "pixel_ratio": "auto",
+       "rendered_position": {
+        "renderedPosition": {
+         "x": 100,
+         "y": 100
+        }
+       },
+       "selection_type": "single",
+       "style_enabled": true,
+       "texture_on_viewport": false,
+       "tooltip_source": "tooltip",
+       "touch_tap_threshold": 8,
+       "user_panning_enabled": true,
+       "user_zooming_enabled": true,
+       "wheel_sensitivity": 1,
+       "zoom": 2,
+       "zooming_enabled": true
+      }
+     },
+     "5b318bc2e17f44b3891520948cfe7384": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "FunctionMaker",
+        "label": "FunctionMaker",
+        "name": "FunctionMaker",
+        "tooltip": "theano.compile.function.types"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 3572.75
+       }
+      }
+     },
+     "5b4e4ca46fed432798507b1d05fc773b": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Elemwise",
+        "label": "Elemwise",
+        "name": "Elemwise",
+        "tooltip": "theano.tensor.elemwise"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 1248.0500000000002
+       }
+      }
+     },
+     "5b96d4b63e25442d853d46aa8d3f2292": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "c74b402b-ed57-4705-81e3-91d9ab8848f9",
+        "source": "In",
+        "target": "Param"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "5c5fc5e51c3f4589908ef330dce0d8db": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "Reversible",
+        "label": "Reversible",
+        "name": "Reversible",
+        "tooltip": "collections.abc"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 4232.85
+       }
+      }
+     },
+     "5d2ef7631b464e13a306a054d29f05ae": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "e933682c-011c-4db3-a3aa-52ad44d1b5f6",
+        "source": "OpenMPOp",
+        "target": "Elemwise"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "5dbf9c5492744434b7b49ae460032af0": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "ProfileStats",
+        "label": "ProfileStats",
+        "name": "ProfileStats",
+        "tooltip": "theano.compile.profiling"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4118.05
+       }
+      }
+     },
+     "5dd39a1e2a854a61a7487519eabad921": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "82333e91-fdda-49e6-a377-01e072cbeb7c",
+        "source": "Op",
+        "target": "Choose"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "5e0aa0dde1c94e929a56396f791f94ee": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "SubtensorPrinter",
+        "label": "SubtensorPrinter",
+        "name": "SubtensorPrinter",
+        "tooltip": "theano.tensor.subtensor"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4290.25
+       }
+      }
+     },
+     "5e6e47b1a4f34d35b2454ef9392cb46f": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "cf6a0a4c-e58b-4c92-a01c-7c2aad522150",
+        "source": "Op",
+        "target": "MPIRecvWait"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "602b531645b64416abdd26fff4b2539f": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "SingletonType",
+        "label": "SingletonType",
+        "name": "SingletonType",
+        "tooltip": "theano.gof.type"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 961.0500000000002
+       }
+      }
+     },
+     "6030cfbbd4bf42f686772d66bb43f59a": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "EmptyConstantError",
+        "label": "EmptyConstantError",
+        "name": "EmptyConstantError",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 3831.05
+       }
+      }
+     },
+     "63840bffd9314dd8954c70079ead8ac9": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "NotScalarConstantError",
+        "label": "NotScalarConstantError",
+        "name": "NotScalarConstantError",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3831.05
+       }
+      }
+     },
+     "661d3e7393a44a1f9a5b6805aea12b52": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "e5a445b2-7458-4eda-93e5-37c34a7f8c2e",
+        "source": "Op",
+        "target": "AdvancedSubtensor1"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "6662f279482e4d9eae8235f9d51d97e0": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "groupby",
+        "label": "groupby",
+        "name": "groupby",
+        "tooltip": "itertools"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4548.55
+       }
+      }
+     },
+     "694e076a78a04fd783103c009257cb97": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "CAReduceDtype",
+        "label": "CAReduceDtype",
+        "name": "CAReduceDtype",
+        "tooltip": "theano.tensor.elemwise"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 1936.85
+       }
+      }
+     },
+     "69ebd4a918be4b099a9550ff5846833c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "113e7aec-f14e-4b21-b568-b8a96c389683",
+        "source": "Type",
+        "target": "SliceType"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "6a62fa57c5724ed49b469289f46aac4d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "8b6f8521-240e-4c9f-94d8-15388b46ebcc",
+        "source": "Op",
+        "target": "MaxAndArgmax"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "6c22662c9a3f45e0a3cc73c87f2df5eb": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "MPIRecv",
+        "label": "MPIRecv",
+        "name": "MPIRecv",
+        "tooltip": "theano.tensor.io"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2510.85
+       }
+      }
+     },
+     "6c4d6f8df1d343198192cfd826b710ac": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Alloc",
+        "label": "Alloc",
+        "name": "Alloc",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1592.45
+       }
+      }
+     },
+     "6cfd3e7073d0475290118090c22a3225": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "bfcde41c-266b-42f8-8935-92e3b761d9bd",
+        "source": "Linker",
+        "target": "CLinker"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "6d11b6053b9e46ba98a36286cf996687": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "AdvancedSubtensor",
+        "label": "AdvancedSubtensor",
+        "name": "AdvancedSubtensor",
+        "tooltip": "theano.tensor.subtensor"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1477.65
+       }
+      }
+     },
+     "6fe29d2821574c6695e0d9c08795ebbf": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "96d2e8a9-7cb7-4b8d-bee2-8b2f1a0d5fee",
+        "source": "Op",
+        "target": "Tile"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "7311e42bdd59408c9a5b4ed1cb738510": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "GraphModel",
+      "state": {
+       "_adj": {
+        "ARange": {},
+        "AdvancedIncSubtensor": {},
+        "AdvancedIncSubtensor1": {},
+        "AdvancedIndexingError": {},
+        "AdvancedSubtensor": {},
+        "AdvancedSubtensor1": {},
+        "Alloc": {},
+        "AllocDiag": {},
+        "AllocEmpty": {},
+        "Apply": {},
+        "Argmax": {},
+        "BaseException": {},
+        "CAReduce": {},
+        "CAReduceDtype": {},
+        "CLinker": {},
+        "COp": {},
+        "Choose": {},
+        "Constant": {},
+        "Container": {},
+        "Default": {},
+        "DiffOp": {},
+        "DimShuffle": {},
+        "DisconnectedType": {},
+        "Dot": {},
+        "DualLinker": {},
+        "Elemwise": {},
+        "EmptyConstantError": {},
+        "Exception": {},
+        "ExtractDiag": {},
+        "Eye": {},
+        "Flatten": {},
+        "FunctionGraph": {},
+        "FunctionMaker": {},
+        "Generic": {},
+        "In": {},
+        "IncSubtensor": {},
+        "InconsistencyError": {},
+        "Iterable": {},
+        "Join": {},
+        "Linker": {},
+        "LoadFromDisk": {},
+        "LocalLinker": {},
+        "MPIRecv": {},
+        "MPIRecvWait": {},
+        "MPISend": {},
+        "MPISendWait": {},
+        "MakeSlice": {},
+        "Max": {},
+        "MaxAndArgmax": {},
+        "Mean": {},
+        "MethodNotDefined": {},
+        "Min": {},
+        "Mode": {},
+        "Node": {},
+        "NoneTypeT": {},
+        "Nonzero": {},
+        "NotScalarConstantError": {},
+        "Op": {},
+        "OpWiseCLinker": {},
+        "OpenMPOp": {},
+        "OrderedDict": {},
+        "OrderedUpdates": {},
+        "Param": {},
+        "ParamsType": {},
+        "PerformLinker": {},
+        "PermuteRowElements": {},
+        "ProfileStats": {},
+        "Rebroadcast": {},
+        "Reshape": {},
+        "Reversible": {},
+        "ScalarFromTensor": {},
+        "Sequence": {},
+        "Shape": {},
+        "ShapeError": {},
+        "SingletonType": {},
+        "SliceConstant": {},
+        "SliceType": {},
+        "SpecifyShape": {},
+        "Split": {},
+        "Subtensor": {},
+        "SubtensorPrinter": {},
+        "Sum": {},
+        "SymbolicInput": {},
+        "SymbolicOutput": {},
+        "TensorConstant": {},
+        "TensorConstantSignature": {},
+        "TensorFromScalar": {},
+        "TensorType": {},
+        "TensorVariable": {},
+        "Tile": {},
+        "Tri": {},
+        "Type": {},
+        "TypeError": {},
+        "Variable": {},
+        "_tensor_py_operators": {},
+        "chain": {},
+        "change_flags": {},
+        "complex": {},
+        "dict": {},
+        "groupby": {},
+        "numeric_grad": {},
+        "object": {},
+        "object2": {},
+        "partial": {},
+        "tuple": {}
+       },
+       "_model_module_version": "^1.0.4",
+       "_view_module": "jupyter-cytoscape",
+       "_view_module_version": "^1.0.4",
+       "edges": [
+        "IPY_MODEL_b957d1be6873454d9515719f59a8e3d5",
+        "IPY_MODEL_bc4ebcd464b146e7bd7b32451f3765b9",
+        "IPY_MODEL_50a68ed55dd94fdca7e6e88ff3ed9819",
+        "IPY_MODEL_e28396f29b0d48eea405864650880146",
+        "IPY_MODEL_b094d7eb6be446b08efec792b9347b5e",
+        "IPY_MODEL_4e36066dda37461db7a3d44151557b42",
+        "IPY_MODEL_87a281bb979c4caa87aa0cebbf25e24e",
+        "IPY_MODEL_0d7745d27dff41e383ecb3da0f739140",
+        "IPY_MODEL_84914a9a28ec4f6985bb921f0e993ee1",
+        "IPY_MODEL_862139780e04429ab6fa38a4a5a238e8",
+        "IPY_MODEL_2904b28264514b6198f00ef1b222b39b",
+        "IPY_MODEL_8abf124c2f7745c8b535c8a9dc18637c",
+        "IPY_MODEL_51d3afad15fa4c08957b4c0f725daa6f",
+        "IPY_MODEL_c608ca10b69149a19703bc377e696402",
+        "IPY_MODEL_213318f3378145c68d2516a214761f53",
+        "IPY_MODEL_c91bbd447bc14e78996d6e8eb0a7120d",
+        "IPY_MODEL_cd9b405b98404d4494d6dd4176068893",
+        "IPY_MODEL_e3eeec9eceb84280a394a4cd0615f001",
+        "IPY_MODEL_b512b89847094349bd0019d83b7384be",
+        "IPY_MODEL_96ccf447ed8f4482bb559349b8bda1ee",
+        "IPY_MODEL_d6ab5a8facb44cf183f189f4efbd147a",
+        "IPY_MODEL_7eccad3f153f4abdb984af8383be4fc8",
+        "IPY_MODEL_81d7573c7c2c40f08a9488b04247cdea",
+        "IPY_MODEL_d8b3af65fb574b33ada7642d7e9040ea",
+        "IPY_MODEL_392e40ee037041f58fde00e9d00abcbe",
+        "IPY_MODEL_ea0fb98c3165401fadc62241430a8049",
+        "IPY_MODEL_6cfd3e7073d0475290118090c22a3225",
+        "IPY_MODEL_48cfb2b2a4ab411cacd1672e0c0320b7",
+        "IPY_MODEL_fc4b8c9c89ba4a32a4c1d9013e87c711",
+        "IPY_MODEL_ca2af3b2f0214f4083114da94f9a6265",
+        "IPY_MODEL_c91cc908ecbb42f8939a87883b3cff82",
+        "IPY_MODEL_8ec3e085d11a48e0b7f7f6007f0bdbc8",
+        "IPY_MODEL_83c193eeca9f4cc685234b81db10a5ae",
+        "IPY_MODEL_e31afffb910a4748b8a00e4015decb3c",
+        "IPY_MODEL_b737bf21224a4eb1af651b5e89131048",
+        "IPY_MODEL_0a9879ad64054a099950c9bf4304a7fc",
+        "IPY_MODEL_69ebd4a918be4b099a9550ff5846833c",
+        "IPY_MODEL_2e4beb5a3ef345c28e4fa60295dd4db5",
+        "IPY_MODEL_5b96d4b63e25442d853d46aa8d3f2292",
+        "IPY_MODEL_ba94e69db84944b4b909b544a1f0c736",
+        "IPY_MODEL_fbe72b157f0e4c31af0416456cf21e82",
+        "IPY_MODEL_1f8f919bae5744fbbf36734a31908659",
+        "IPY_MODEL_476b003029da441685039f353ac715bb",
+        "IPY_MODEL_297cd1cb263a4ad0b2321e384ed2d8b7",
+        "IPY_MODEL_0388b8b29c34472996cc4cdb6407b049",
+        "IPY_MODEL_531de1d3d4614a86a8a4deec43b42694",
+        "IPY_MODEL_201dd4bc7cae4b2e8306036ecbd381c2",
+        "IPY_MODEL_9c27413d5a9944f49568c46ea434991d",
+        "IPY_MODEL_dd4d3c38de3b4f4abef15264cdd4d065",
+        "IPY_MODEL_986fb0512dc44511953f55e7a520c375",
+        "IPY_MODEL_92298070bd2c4163829059117c7f3a4d",
+        "IPY_MODEL_a49d8fa18cd74e59ae4d431175dc2fef",
+        "IPY_MODEL_3135f96b0c574e9d8841c33c9263b6c6",
+        "IPY_MODEL_661d3e7393a44a1f9a5b6805aea12b52",
+        "IPY_MODEL_2340c07adc6044768bbe6b9e4baeec6d",
+        "IPY_MODEL_def84d61ed6247a7a97f9c16a977ac55",
+        "IPY_MODEL_c418b794aab042fd81a08ac2d80ebbc7",
+        "IPY_MODEL_94ce1896cf8a421fa416360261b7eb51",
+        "IPY_MODEL_4c0533b9a7204bada7abff075dd771e8",
+        "IPY_MODEL_5dd39a1e2a854a61a7487519eabad921",
+        "IPY_MODEL_d2b9ab27f2b54b0bba169da9504ac9b3",
+        "IPY_MODEL_87ba547678484588bfdb660042b333bb",
+        "IPY_MODEL_560c485869ab42a4b628e3007d3f2ea1",
+        "IPY_MODEL_1b3efa11ba6d4b80b2c1d2345e8752e8",
+        "IPY_MODEL_77d8e1e663e6413c875db905d92c00a7",
+        "IPY_MODEL_472cec6b1556423facf672a58d572177",
+        "IPY_MODEL_f6a7f6eb20ad4c6087f961161fe95178",
+        "IPY_MODEL_1cbf9bc46ad1449bbdf21ff4c3263450",
+        "IPY_MODEL_4c1cde2663ed4ac2b1c6944666970439",
+        "IPY_MODEL_4582f058ac0b4c4c8f147dd5822d8a19",
+        "IPY_MODEL_8fce41f5052f4ebfa3c0c34510b27c7c",
+        "IPY_MODEL_5e6e47b1a4f34d35b2454ef9392cb46f",
+        "IPY_MODEL_c13f23d417b3483f9a642697e8e0621e",
+        "IPY_MODEL_d16d2bcc83e6494cad021d11d8ef63df",
+        "IPY_MODEL_8fb4c086c2b042a2938c021b9ca7fe2d",
+        "IPY_MODEL_6a62fa57c5724ed49b469289f46aac4d",
+        "IPY_MODEL_437a3da0f49a4042a8def494764130d5",
+        "IPY_MODEL_9c8979fe78e142c78a83d105d1eea8e1",
+        "IPY_MODEL_b676d07a99d24f60891b0fe2dea8caaa",
+        "IPY_MODEL_b43d56094008486697ad18c4cdea52db",
+        "IPY_MODEL_9275d10f0c4842459efd9c9b3d88645b",
+        "IPY_MODEL_794d82636fbb467680b7d41527226d9a",
+        "IPY_MODEL_002d6da2e6fe4cb3925e3889b33129cf",
+        "IPY_MODEL_8922fe3c83cc4590b05465146f82f6e5",
+        "IPY_MODEL_0999a7817f9943ffb8dc09adbc50d7ec",
+        "IPY_MODEL_bd2c2d666d954155bf63ff2b139cfbdf",
+        "IPY_MODEL_6fe29d2821574c6695e0d9c08795ebbf",
+        "IPY_MODEL_35cb6efbe0894682aa751e3090db3fb8",
+        "IPY_MODEL_5d2ef7631b464e13a306a054d29f05ae",
+        "IPY_MODEL_45285d5fa8b846418fc1597227b29b6f",
+        "IPY_MODEL_75367771cace45b996893355d2fa4901",
+        "IPY_MODEL_89501976951b4a73b6be6ab19d389ab6",
+        "IPY_MODEL_fe907466d90b4c979aac96acdafc08f7",
+        "IPY_MODEL_98a781e7aa654a1f9253ad544a2cc070",
+        "IPY_MODEL_c0f726148d954e058dadfb3257488e68",
+        "IPY_MODEL_33e168a3f9074518be942c01863d3551",
+        "IPY_MODEL_93909cb6a078481ca24c7f55c91c3e1f",
+        "IPY_MODEL_b7a51a6eb28b45538b736a8cae7a90fa",
+        "IPY_MODEL_4ae475a73f9a419395a16520cdaafe68",
+        "IPY_MODEL_c70dcce052ca4c19a499744a26758c6c",
+        "IPY_MODEL_c2829437ac854a0eaf68a98fdc769c47",
+        "IPY_MODEL_0f3793e67c574ae6b16d99f0ea76c654",
+        "IPY_MODEL_97124f78b4a34f8b9cc8a23cb74fd8ea",
+        "IPY_MODEL_46cdcb19451c44a69b9c4b76b0c32b54"
+       ],
+       "nodes": [
+        "IPY_MODEL_4f94e7e7192b43788a33eeee0bdebd6c",
+        "IPY_MODEL_18a7eb283b9549db8df3539b5e847cef",
+        "IPY_MODEL_d6c648f5dc2c4f60961a47d23c8aca37",
+        "IPY_MODEL_d946f9e1c43b44e59936f7f1d5d2b038",
+        "IPY_MODEL_f9d3cab360f9411aa4153f5bf9718a23",
+        "IPY_MODEL_1ca7a7bbe6314bb2ba2df5c065fb3de3",
+        "IPY_MODEL_4c5d8e778e1c42eaafee221a498370a9",
+        "IPY_MODEL_1d62ad221ed1429fa940456a7c54affc",
+        "IPY_MODEL_f78122391ce1474f8333a74c0c524e14",
+        "IPY_MODEL_8ee49be361304d43b19d192e2c297044",
+        "IPY_MODEL_56600419be624fc4ba7ca01740dcba8c",
+        "IPY_MODEL_5b318bc2e17f44b3891520948cfe7384",
+        "IPY_MODEL_3b0145e58db14f759bacff4f3922f7e8",
+        "IPY_MODEL_602b531645b64416abdd26fff4b2539f",
+        "IPY_MODEL_aba99ad304184228b8596b30ff1e7fdc",
+        "IPY_MODEL_cdf958a7775546098748ff7efd238441",
+        "IPY_MODEL_e02a9595b82d42f1a6b5387cd0fca04e",
+        "IPY_MODEL_1b18dd448439490b93652283173adce2",
+        "IPY_MODEL_2ca85c74202d428b9c8a18081e980267",
+        "IPY_MODEL_5861dab966bd40df9563ffa73daae29e",
+        "IPY_MODEL_e78d2548ef4b47bd953d6991b845845a",
+        "IPY_MODEL_973b7d9cf2bf47ce8e7729138ee91036",
+        "IPY_MODEL_52b4cfa7813b46208806a812cf930e52",
+        "IPY_MODEL_7e7323b768c54c5d852b4f30671079c7",
+        "IPY_MODEL_a90396eaa06f4b3fa27cf33eb596d052",
+        "IPY_MODEL_52c992870efd43219229c761a4692119",
+        "IPY_MODEL_439d468e187945b59d7f536562ad9342",
+        "IPY_MODEL_aa6c6a64b22644e8ae665583133c7a71",
+        "IPY_MODEL_3faca9dc920f4d5c87dea21e47939c3e",
+        "IPY_MODEL_b9bb141a44f54451825f2a61931b67f5",
+        "IPY_MODEL_8aaec7fe1a594a4fbcb178112dc4ef6e",
+        "IPY_MODEL_5dbf9c5492744434b7b49ae460032af0",
+        "IPY_MODEL_1fa67f7ab2b140969b119bc0b1d472ff",
+        "IPY_MODEL_f6e463a894184c9b9405915013d53706",
+        "IPY_MODEL_9e45f715bd07405c960a7c5c904d8ba3",
+        "IPY_MODEL_a71be403a23a4868babacc15935bfdf9",
+        "IPY_MODEL_40b0bceafb2448878ce3b6c1bef953d9",
+        "IPY_MODEL_53777e18249747318bf7ea8396791c8b",
+        "IPY_MODEL_6d11b6053b9e46ba98a36286cf996687",
+        "IPY_MODEL_1ff84084f0b0477985fa12e6f91600ec",
+        "IPY_MODEL_6c4d6f8df1d343198192cfd826b710ac",
+        "IPY_MODEL_c6225cd776ba40cbb6499c432771cd32",
+        "IPY_MODEL_87581980db644a73934e38d2c6d24cca",
+        "IPY_MODEL_7708ec2fe77549bea27f22d012b0e6a5",
+        "IPY_MODEL_aeaa5a68fd5b4d90a9d47f1540ccf193",
+        "IPY_MODEL_c231c4025f944bccafcc2ab5ea419fac",
+        "IPY_MODEL_bcdcc13e312a473599b232d9b9caaf81",
+        "IPY_MODEL_ea1e064749c04ab3a3437990c5fb6188",
+        "IPY_MODEL_4b23eea474794b6795a26c95d88079df",
+        "IPY_MODEL_c4ba9842bfaf45f7b5622b82fab7e27d",
+        "IPY_MODEL_cf22e4419cc04f91aaa635449a0522bc",
+        "IPY_MODEL_d819999be0374e66808d5d0d15db1c78",
+        "IPY_MODEL_5b4e4ca46fed432798507b1d05fc773b",
+        "IPY_MODEL_6030cfbbd4bf42f686772d66bb43f59a",
+        "IPY_MODEL_63840bffd9314dd8954c70079ead8ac9",
+        "IPY_MODEL_850e399f3aa74075929578df68cda19c",
+        "IPY_MODEL_0c9f9f3f606b4304b79f1534380d217d",
+        "IPY_MODEL_0a8c035be3cb43ee90bc471e30ded51d",
+        "IPY_MODEL_b58c0f170fc1414fb584c62d6ed06bae",
+        "IPY_MODEL_44c717bbd0e444ed806a84de8caaaf4c",
+        "IPY_MODEL_a21ee2730fb744199194603fb14b948b",
+        "IPY_MODEL_6c22662c9a3f45e0a3cc73c87f2df5eb",
+        "IPY_MODEL_94f23270e91e430ab1c96ac408f84c14",
+        "IPY_MODEL_4d6dc4e13d6e4586a5ac9ff181a48d61",
+        "IPY_MODEL_35d25408d0874a9db36b0a170e549203",
+        "IPY_MODEL_768a8d816c8f4aa1b6e87a313e91155f",
+        "IPY_MODEL_e9c39013c455480eadc1871ae2f5c5c7",
+        "IPY_MODEL_db0ad294cbaa4d5b890f8bf2b17167bd",
+        "IPY_MODEL_ca86318bea7349e9afd234877657e1ed",
+        "IPY_MODEL_efb11436ee6446bcb841418fa64710a0",
+        "IPY_MODEL_cee1f44fbf5f4d2ca3c7bae46b969f37",
+        "IPY_MODEL_27ff6520d333492ba76fc1c8b4c8f880",
+        "IPY_MODEL_105d941de88e40b2952c28a5e4564bd2",
+        "IPY_MODEL_fcdfb0983d674aa8b17f0c3bfa0e8027",
+        "IPY_MODEL_9b49d9ac76fa420987b1c19fa6c48170",
+        "IPY_MODEL_9b9db182836e435cbed1218f345e217d",
+        "IPY_MODEL_d8d5da20f0874536b416b08e6adba1ad",
+        "IPY_MODEL_9fa1a33fb93f4c159aea6a7d1672c5ab",
+        "IPY_MODEL_fee5b74fd8db4035a17e6f7edf1ce6b8",
+        "IPY_MODEL_5c5fc5e51c3f4589908ef330dce0d8db",
+        "IPY_MODEL_a1549a47109946d3ab077a2674e42fa3",
+        "IPY_MODEL_376b7ad031184a71aedb281351713756",
+        "IPY_MODEL_a4a3988c0b0748d1bd089109fa1a755e",
+        "IPY_MODEL_a389825deccd4e07b2db24a4d3ccb99a",
+        "IPY_MODEL_43c93d8aa9fd4c52a11cbfcf1d1ccf0a",
+        "IPY_MODEL_4b84d219bb0f4afb9688d95920eb1b22",
+        "IPY_MODEL_f34e89c901714d77bd6d9b54e3907c90",
+        "IPY_MODEL_36bf721b1daf4a03a9e5c2ae770da8b7",
+        "IPY_MODEL_5e0aa0dde1c94e929a56396f791f94ee",
+        "IPY_MODEL_9022ac5f9da44ca5a22d521ab09642e1",
+        "IPY_MODEL_694e076a78a04fd783103c009257cb97",
+        "IPY_MODEL_f390cba96b8344a58577128212a63e77",
+        "IPY_MODEL_acb1014657134b6591e2ded3c0bc51d8",
+        "IPY_MODEL_1714002d62074ab187c1630ef9bff6cf",
+        "IPY_MODEL_b9876357098a444682d2f23f4b48017e",
+        "IPY_MODEL_c4127a8ef51d41678911a3f8adfca0d4",
+        "IPY_MODEL_bb139baf325c40e7818fd42fd7da38f0",
+        "IPY_MODEL_3d38d2af0f87432f987ab52d1598da55",
+        "IPY_MODEL_56dc29367cfc470ba34aeac170534625",
+        "IPY_MODEL_e47a7925dd2a4d5d9afcfbc800c5d329",
+        "IPY_MODEL_f714b3565f974f23a8ba38e8a2c421c6",
+        "IPY_MODEL_6662f279482e4d9eae8235f9d51d97e0",
+        "IPY_MODEL_4a498380b94c40389e39b8a9b1d79aa4",
+        "IPY_MODEL_9793dc298e17495bbe5d28ab1e26761f",
+        "IPY_MODEL_54446d71dd29431585ba6016f59a038a"
+       ]
+      }
+     },
+     "75367771cace45b996893355d2fa4901": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "ff0d244a-19aa-4977-8c45-8e3da6f1b357",
+        "source": "dict",
+        "target": "OrderedDict"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "768a8d816c8f4aa1b6e87a313e91155f": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "MakeSlice",
+        "label": "MakeSlice",
+        "name": "MakeSlice",
+        "tooltip": "theano.tensor.type_other"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2740.45
+       }
+      }
+     },
+     "7708ec2fe77549bea27f22d012b0e6a5": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Argmax",
+        "label": "Argmax",
+        "name": "Argmax",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1764.65
+       }
+      }
+     },
+     "77d8e1e663e6413c875db905d92c00a7": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "73d0c70b-7296-4f2b-9e59-f8f42b777a0e",
+        "source": "Op",
+        "target": "ExtractDiag"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "794d82636fbb467680b7d41527226d9a": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "364377aa-a911-497e-bdde-aec81bedbfa6",
+        "source": "Op",
+        "target": "Shape"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "7e7323b768c54c5d852b4f30671079c7": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "OpWiseCLinker",
+        "label": "OpWiseCLinker",
+        "name": "OpWiseCLinker",
+        "tooltip": "theano.gof.cc"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3544.05
+       }
+      }
+     },
+     "7eccad3f153f4abdb984af8383be4fc8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "f45f05ee-a03a-4ccf-b68a-9968cd6f9884",
+        "source": "object",
+        "target": "chain"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "81d7573c7c2c40f08a9488b04247cdea": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "cc5b63f9-e2ee-482e-b7a9-d6bb2c54d8ba",
+        "source": "object",
+        "target": "groupby"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "83c193eeca9f4cc685234b81db10a5ae": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "06394351-a0c5-4d4c-8bce-f8de699ea93a",
+        "source": "SingletonType",
+        "target": "Generic"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "84914a9a28ec4f6985bb921f0e993ee1": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "4c181aae-30d5-4d14-b971-93822fa61cff",
+        "source": "object",
+        "target": "Container"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "850e399f3aa74075929578df68cda19c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "ExtractDiag",
+        "label": "ExtractDiag",
+        "name": "ExtractDiag",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2166.45
+       }
+      }
+     },
+     "862139780e04429ab6fa38a4a5a238e8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "520d7069-c033-4ce2-99b5-53bcf0778180",
+        "source": "object",
+        "target": "FunctionMaker"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "87581980db644a73934e38d2c6d24cca": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "AllocEmpty",
+        "label": "AllocEmpty",
+        "name": "AllocEmpty",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1707.25
+       }
+      }
+     },
+     "87a281bb979c4caa87aa0cebbf25e24e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "d2772004-e38e-4eb6-9b81-01f982bdd2c4",
+        "source": "object",
+        "target": "object2"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "87ba547678484588bfdb660042b333bb": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "430e86a9-6867-4421-9661-7ec8308d30cf",
+        "source": "Op",
+        "target": "DiffOp"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "8922fe3c83cc4590b05465146f82f6e5": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "90f297bf-1f6d-4b42-997d-8cb17e3f603c",
+        "source": "Op",
+        "target": "Split"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "89501976951b4a73b6be6ab19d389ab6": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "8228bcb7-dc79-4ac5-8fc4-e702e173730e",
+        "source": "TypeError",
+        "target": "AdvancedIndexingError"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "8aaec7fe1a594a4fbcb178112dc4ef6e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "PerformLinker",
+        "label": "PerformLinker",
+        "name": "PerformLinker",
+        "tooltip": "theano.gof.link"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3601.45
+       }
+      }
+     },
+     "8abf124c2f7745c8b535c8a9dc18637c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "2423ba04-7123-49b7-b0e9-9a099ac85c70",
+        "source": "object",
+        "target": "BaseException"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "8ec3e085d11a48e0b7f7f6007f0bdbc8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "d4b5097c-60ab-4c10-9da6-e4e2df284128",
+        "source": "Generic",
+        "target": "NoneTypeT"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "8ee49be361304d43b19d192e2c297044": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "DualLinker",
+        "label": "DualLinker",
+        "name": "DualLinker",
+        "tooltip": "theano.gof.cc"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 3429.25
+       }
+      }
+     },
+     "8fb4c086c2b042a2938c021b9ca7fe2d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "edbf16d3-a937-4e82-a90b-f1d1b400f05c",
+        "source": "Op",
+        "target": "MakeSlice"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "8fce41f5052f4ebfa3c0c34510b27c7c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "93c48020-c297-4e26-a185-6eb3803fc8df",
+        "source": "Op",
+        "target": "MPIRecv"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "9022ac5f9da44ca5a22d521ab09642e1": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Sum",
+        "label": "Sum",
+        "name": "Sum",
+        "tooltip": "theano.tensor.elemwise"
+       },
+       "position": {
+        "x": 624.175,
+        "y": 1936.85
+       }
+      }
+     },
+     "92298070bd2c4163829059117c7f3a4d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "48ec98e0-f7b9-4833-a371-0a979640f138",
+        "source": "Op",
+        "target": "AdvancedIncSubtensor"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "9275d10f0c4842459efd9c9b3d88645b": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "a46bd10d-1750-4551-9bca-b2a263987763",
+        "source": "Op",
+        "target": "ScalarFromTensor"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "93909cb6a078481ca24c7f55c91c3e1f": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "3db492d8-2f77-4fbc-95c7-13af8bf70d04",
+        "source": "COp",
+        "target": "DimShuffle"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "94ce1896cf8a421fa416360261b7eb51": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "9e73ebda-a8bb-44ba-8e89-629563276c2a",
+        "source": "Op",
+        "target": "Argmax"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "94f23270e91e430ab1c96ac408f84c14": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "MPIRecvWait",
+        "label": "MPIRecvWait",
+        "name": "MPIRecvWait",
+        "tooltip": "theano.tensor.io"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2568.25
+       }
+      }
+     },
+     "96ccf447ed8f4482bb559349b8bda1ee": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "bc9c0e10-2bf9-4119-ae67-db7692fa4ce0",
+        "source": "object",
+        "target": "_tensor_py_operators"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "97124f78b4a34f8b9cc8a23cb74fd8ea": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "dbb47bba-931d-4f39-9814-ec5ebe68bfe2",
+        "source": "_tensor_py_operators",
+        "target": "TensorVariable"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "973b7d9cf2bf47ce8e7729138ee91036": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "Mode",
+        "label": "Mode",
+        "name": "Mode",
+        "tooltip": "theano.compile.mode"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 3945.85
+       }
+      }
+     },
+     "9793dc298e17495bbe5d28ab1e26761f": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "partial",
+        "label": "partial",
+        "name": "partial",
+        "tooltip": "functools"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4663.35
+       }
+      }
+     },
+     "986fb0512dc44511953f55e7a520c375": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "5a97a4fa-048b-4864-a4a6-677fc2e98a22",
+        "source": "Op",
+        "target": "ARange"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "98a781e7aa654a1f9253ad544a2cc070": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "27d7545a-e78c-45f5-b069-2302e77bd5d7",
+        "source": "CAReduce",
+        "target": "Mean"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "9b49d9ac76fa420987b1c19fa6c48170": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "PermuteRowElements",
+        "label": "PermuteRowElements",
+        "name": "PermuteRowElements",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2912.65
+       }
+      }
+     },
+     "9b9db182836e435cbed1218f345e217d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "Rebroadcast",
+        "label": "Rebroadcast",
+        "name": "Rebroadcast",
+        "tooltip": "theano.compile.ops"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2970.05
+       }
+      }
+     },
+     "9c27413d5a9944f49568c46ea434991d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "7e45b44e-6ce3-4d82-8a12-3e1146a90fe0",
+        "source": "LocalLinker",
+        "target": "PerformLinker"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "9c8979fe78e142c78a83d105d1eea8e1": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "d310d363-ea04-4150-a091-8952907e0402",
+        "source": "Op",
+        "target": "PermuteRowElements"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "9e45f715bd07405c960a7c5c904d8ba3": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "AdvancedIncSubtensor",
+        "label": "AdvancedIncSubtensor",
+        "name": "AdvancedIncSubtensor",
+        "tooltip": "theano.tensor.subtensor"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1362.8500000000001
+       }
+      }
+     },
+     "9fa1a33fb93f4c159aea6a7d1672c5ab": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "ScalarFromTensor",
+        "label": "ScalarFromTensor",
+        "name": "ScalarFromTensor",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3084.85
+       }
+      }
+     },
+     "a1549a47109946d3ab077a2674e42fa3": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "Iterable",
+        "label": "Iterable",
+        "name": "Iterable",
+        "tooltip": "collections.abc"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4232.85
+       }
+      }
+     },
+     "a21ee2730fb744199194603fb14b948b": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "LoadFromDisk",
+        "label": "LoadFromDisk",
+        "name": "LoadFromDisk",
+        "tooltip": "theano.tensor.io"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2453.45
+       }
+      }
+     },
+     "a389825deccd4e07b2db24a4d3ccb99a": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "SliceConstant",
+        "label": "SliceConstant",
+        "name": "SliceConstant",
+        "tooltip": "theano.tensor.type_other"
+       },
+       "position": {
+        "x": 624.175,
+        "y": 903.6500000000001
+       }
+      }
+     },
+     "a49d8fa18cd74e59ae4d431175dc2fef": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "a92c3c05-a37c-4a9e-8c67-8d0dd0e2ff6e",
+        "source": "Op",
+        "target": "AdvancedIncSubtensor1"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "a4a3988c0b0748d1bd089109fa1a755e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "ShapeError",
+        "label": "ShapeError",
+        "name": "ShapeError",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3945.85
+       }
+      }
+     },
+     "a71be403a23a4868babacc15935bfdf9": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "AdvancedIncSubtensor1",
+        "label": "AdvancedIncSubtensor1",
+        "name": "AdvancedIncSubtensor1",
+        "tooltip": "theano.tensor.subtensor"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1420.25
+       }
+      }
+     },
+     "a90396eaa06f4b3fa27cf33eb596d052": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "OpenMPOp",
+        "label": "OpenMPOp",
+        "name": "OpenMPOp",
+        "tooltip": "theano.gof.op"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1248.0500000000002
+       }
+      }
+     },
+     "aa6c6a64b22644e8ae665583133c7a71": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "dict",
+        "label": "dict",
+        "name": "dict",
+        "tooltip": "builtins"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4003.25
+       }
+      }
+     },
+     "aba99ad304184228b8596b30ff1e7fdc": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Type",
+        "label": "Type",
+        "name": "Type",
+        "tooltip": "theano.gof.type"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 1018.45
+       }
+      }
+     },
+     "acb1014657134b6591e2ded3c0bc51d8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "TensorConstant",
+        "label": "TensorConstant",
+        "name": "TensorConstant",
+        "tooltip": "theano.tensor.var"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 4318.95
+       }
+      }
+     },
+     "aeaa5a68fd5b4d90a9d47f1540ccf193": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "CAReduce",
+        "label": "CAReduce",
+        "name": "CAReduce",
+        "tooltip": "theano.tensor.elemwise"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1822.0500000000002
+       }
+      }
+     },
+     "b094d7eb6be446b08efec792b9347b5e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "4e856c40-f0cb-4564-8173-31e577d6d885",
+        "source": "object2",
+        "target": "Type"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "b43d56094008486697ad18c4cdea52db": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "8c630543-6071-403b-9611-3f9b4fde9253",
+        "source": "Op",
+        "target": "Reshape"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "b512b89847094349bd0019d83b7384be": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "1d971698-b768-4da7-b63b-91d826ca7af8",
+        "source": "object",
+        "target": "SubtensorPrinter"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "b58c0f170fc1414fb584c62d6ed06bae": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "IncSubtensor",
+        "label": "IncSubtensor",
+        "name": "IncSubtensor",
+        "tooltip": "theano.tensor.subtensor"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2338.65
+       }
+      }
+     },
+     "b676d07a99d24f60891b0fe2dea8caaa": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "d710da5e-83ab-4d2a-bc80-1082391f9c00",
+        "source": "Op",
+        "target": "Rebroadcast"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "b737bf21224a4eb1af651b5e89131048": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "81617f62-66d8-4ef8-a2d5-20d51d7b48bc",
+        "source": "Type",
+        "target": "DisconnectedType"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "b7a51a6eb28b45538b736a8cae7a90fa": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "e02a98a4-ac6e-4c9a-abed-856e16cd544a",
+        "source": "NotScalarConstantError",
+        "target": "EmptyConstantError"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "b957d1be6873454d9515719f59a8e3d5": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "bb929f58-f10b-4478-9f61-3d5460bb1397",
+        "source": "Node",
+        "target": "Apply"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "b9876357098a444682d2f23f4b48017e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "TensorConstantSignature",
+        "label": "TensorConstantSignature",
+        "name": "TensorConstantSignature",
+        "tooltip": "theano.tensor.var"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 4433.75
+       }
+      }
+     },
+     "b9bb141a44f54451825f2a61931b67f5": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "Param",
+        "label": "Param",
+        "name": "Param",
+        "tooltip": "theano.compile.function.pfunc"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3658.85
+       }
+      }
+     },
+     "ba94e69db84944b4b909b544a1f0c736": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "7371cc97-83cf-4155-8962-0730ebb58faa",
+        "source": "SymbolicInput",
+        "target": "In"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "bb139baf325c40e7818fd42fd7da38f0": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "TensorFromScalar",
+        "label": "TensorFromScalar",
+        "name": "TensorFromScalar",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3371.85
+       }
+      }
+     },
+     "bc4ebcd464b146e7bd7b32451f3765b9": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "439a7dca-42ab-4666-be0f-e63804178a62",
+        "source": "Node",
+        "target": "Variable"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "bcdcc13e312a473599b232d9b9caaf81": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Default",
+        "label": "Default",
+        "name": "Default",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1936.85
+       }
+      }
+     },
+     "bd2c2d666d954155bf63ff2b139cfbdf": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "1cbadee2-cd94-4f56-a8c1-8a594ea31503",
+        "source": "Op",
+        "target": "TensorFromScalar"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "c0f726148d954e058dadfb3257488e68": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "323dc02c-f0ad-4247-91ed-b4ab50cf087f",
+        "source": "CAReduce",
+        "target": "Min"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "c13f23d417b3483f9a642697e8e0621e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "30ef3779-8944-42d2-bb28-6457565bee3c",
+        "source": "Op",
+        "target": "MPISend"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "c231c4025f944bccafcc2ab5ea419fac": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Choose",
+        "label": "Choose",
+        "name": "Choose",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1879.45
+       }
+      }
+     },
+     "c2829437ac854a0eaf68a98fdc769c47": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "53d12c08-94e1-47de-9509-958495922399",
+        "source": "CAReduceDtype",
+        "target": "Sum"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "c4127a8ef51d41678911a3f8adfca0d4": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "tuple",
+        "label": "tuple",
+        "name": "tuple",
+        "tooltip": "builtins"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4433.75
+       }
+      }
+     },
+     "c418b794aab042fd81a08ac2d80ebbc7": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "69e6dd3b-d8c9-4a9e-b348-6399e0b53851",
+        "source": "Op",
+        "target": "AllocEmpty"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "c4ba9842bfaf45f7b5622b82fab7e27d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "COp",
+        "label": "COp",
+        "name": "COp",
+        "tooltip": "theano.gof.op"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2051.65
+       }
+      }
+     },
+     "c608ca10b69149a19703bc377e696402": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "3fbd975b-913a-4c71-a17f-4ac647e505dc",
+        "source": "object",
+        "target": "dict"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "c6225cd776ba40cbb6499c432771cd32": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "AllocDiag",
+        "label": "AllocDiag",
+        "name": "AllocDiag",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1649.8500000000001
+       }
+      }
+     },
+     "c70dcce052ca4c19a499744a26758c6c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "152a8428-812b-4e3c-b66c-f85d22d25136",
+        "source": "Iterable",
+        "target": "Reversible"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "c91bbd447bc14e78996d6e8eb0a7120d": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "ad1bc663-4ede-4e49-a59e-ae06aa672d83",
+        "source": "object",
+        "target": "ProfileStats"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "c91cc908ecbb42f8939a87883b3cff82": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "50bf51c8-1a9d-45db-8dd1-ca4a493b307b",
+        "source": "Variable",
+        "target": "Constant"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "ca2af3b2f0214f4083114da94f9a6265": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "d127d904-453d-4925-b6cd-ba7cd4681dd9",
+        "source": "Constant",
+        "target": "SliceConstant"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "ca86318bea7349e9afd234877657e1ed": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Mean",
+        "label": "Mean",
+        "name": "Mean",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 1592.45
+       }
+      }
+     },
+     "cd9b405b98404d4494d6dd4176068893": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "1c3ff7a0-bb4d-4d94-aa52-9f7060b6784f",
+        "source": "object",
+        "target": "change_flags"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "cdf958a7775546098748ff7efd238441": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "In",
+        "label": "In",
+        "name": "In",
+        "tooltip": "theano.compile.io"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 3658.85
+       }
+      }
+     },
+     "cee1f44fbf5f4d2ca3c7bae46b969f37": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Min",
+        "label": "Min",
+        "name": "Min",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 1879.45
+       }
+      }
+     },
+     "cf22e4419cc04f91aaa635449a0522bc": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "green",
+        "id": "DisconnectedType",
+        "label": "DisconnectedType",
+        "name": "DisconnectedType",
+        "tooltip": "theano.gradient"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1018.45
+       }
+      }
+     },
+     "d16d2bcc83e6494cad021d11d8ef63df": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "ea1756ea-d472-4440-a99b-14829ea4d7d6",
+        "source": "Op",
+        "target": "MPISendWait"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "d2b9ab27f2b54b0bba169da9504ac9b3": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "ddc6ad94-3eaf-4df4-a19f-8085fdc63a03",
+        "source": "Op",
+        "target": "Default"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "d6ab5a8facb44cf183f189f4efbd147a": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "00fd44d5-9d89-47c0-9849-68ff9382d35d",
+        "source": "object",
+        "target": "tuple"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "d6c648f5dc2c4f60961a47d23c8aca37": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "object2",
+        "label": "object2",
+        "name": "object2",
+        "tooltip": "theano.gof.utils"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 1047.15
+       }
+      }
+     },
+     "d819999be0374e66808d5d0d15db1c78": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Dot",
+        "label": "Dot",
+        "name": "Dot",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2109.05
+       }
+      }
+     },
+     "d8b3af65fb574b33ada7642d7e9040ea": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "453423ca-4e2c-4281-b2c6-3d6a0c87e228",
+        "source": "object",
+        "target": "numeric_grad"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "d8d5da20f0874536b416b08e6adba1ad": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Reshape",
+        "label": "Reshape",
+        "name": "Reshape",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3027.45
+       }
+      }
+     },
+     "d946f9e1c43b44e59936f7f1d5d2b038": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "object",
+        "label": "object",
+        "name": "object",
+        "tooltip": "builtins"
+       },
+       "position": {
+        "x": 123.32500000000002,
+        "y": 4146.75
+       }
+      }
+     },
+     "db0ad294cbaa4d5b890f8bf2b17167bd": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "MaxAndArgmax",
+        "label": "MaxAndArgmax",
+        "name": "MaxAndArgmax",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 2797.85
+       }
+      }
+     },
+     "dd4d3c38de3b4f4abef15264cdd4d065": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "a99398bc-3d78-48cd-975a-9cf1ff628460",
+        "source": "Op",
+        "target": "OpenMPOp"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "def84d61ed6247a7a97f9c16a977ac55": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "cef15f7f-7fc4-4860-af92-7d66c1731999",
+        "source": "Op",
+        "target": "AllocDiag"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "e02a9595b82d42f1a6b5387cd0fca04e": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "red",
+        "id": "SymbolicInput",
+        "label": "SymbolicInput",
+        "name": "SymbolicInput",
+        "tooltip": "theano.compile.io"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 3658.85
+       }
+      }
+     },
+     "e28396f29b0d48eea405864650880146": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "aa7f9263-1784-4e44-b446-4b35139815ba",
+        "source": "object2",
+        "target": "FunctionGraph"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "e31afffb910a4748b8a00e4015decb3c": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "3cd78bed-424e-44e8-8bb8-e6a111b29ebd",
+        "source": "Type",
+        "target": "SingletonType"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "e3eeec9eceb84280a394a4cd0615f001": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "7c901020-4ec5-45e4-8422-2975861f5b43",
+        "source": "object",
+        "target": "Iterable"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "e47a7925dd2a4d5d9afcfbc800c5d329": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Tri",
+        "label": "Tri",
+        "name": "Tri",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3486.65
+       }
+      }
+     },
+     "e78d2548ef4b47bd953d6991b845845a": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "LocalLinker",
+        "label": "LocalLinker",
+        "name": "LocalLinker",
+        "tooltip": "theano.gof.link"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 3544.05
+       }
+      }
+     },
+     "e9c39013c455480eadc1871ae2f5c5c7": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Max",
+        "label": "Max",
+        "name": "Max",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 531.425,
+        "y": 1535.0500000000002
+       }
+      }
+     },
+     "ea0fb98c3165401fadc62241430a8049": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "5bea532b-d8f5-429f-88fc-1a4f0ecee47d",
+        "source": "object",
+        "target": "complex"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "ea1e064749c04ab3a3437990c5fb6188": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "DiffOp",
+        "label": "DiffOp",
+        "name": "DiffOp",
+        "tooltip": "theano.tensor.extra_ops"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1994.25
+       }
+      }
+     },
+     "efb11436ee6446bcb841418fa64710a0": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "MethodNotDefined",
+        "label": "MethodNotDefined",
+        "name": "MethodNotDefined",
+        "tooltip": "theano.gof.utils"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3888.45
+       }
+      }
+     },
+     "f34e89c901714d77bd6d9b54e3907c90": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "Split",
+        "label": "Split",
+        "name": "Split",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 3257.05
+       }
+      }
+     },
+     "f390cba96b8344a58577128212a63e77": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "TensorType",
+        "label": "TensorType",
+        "name": "TensorType",
+        "tooltip": "theano.tensor.type"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1190.65
+       }
+      }
+     },
+     "f6a7f6eb20ad4c6087f961161fe95178": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "3b3b0590-a6c7-4d2f-bb19-e0a5dc32a153",
+        "source": "Op",
+        "target": "Flatten"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "f6e463a894184c9b9405915013d53706": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "blue",
+        "id": "ARange",
+        "label": "ARange",
+        "name": "ARange",
+        "tooltip": "theano.tensor.basic"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1305.45
+       }
+      }
+     },
+     "f714b3565f974f23a8ba38e8a2c421c6": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "chain",
+        "label": "chain",
+        "name": "chain",
+        "tooltip": "itertools"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 4491.15
+       }
+      }
+     },
+     "f78122391ce1474f8333a74c0c524e14": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "Container",
+        "label": "Container",
+        "name": "Container",
+        "tooltip": "theano.gof.link"
+       },
+       "position": {
+        "x": 203.47500000000002,
+        "y": 3515.35
+       }
+      }
+     },
+     "f9d3cab360f9411aa4153f5bf9718a23": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "CLinker",
+        "label": "CLinker",
+        "name": "CLinker",
+        "tooltip": "theano.gof.cc"
+       },
+       "position": {
+        "x": 311.625,
+        "y": 3371.85
+       }
+      }
+     },
+     "fbe72b157f0e4c31af0416456cf21e82": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "6c5ef2e0-8168-484c-8f08-674d182481e3",
+        "source": "Exception",
+        "target": "InconsistencyError"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "fc4b8c9c89ba4a32a4c1d9013e87c711": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "b1a8eaef-16a3-4d0a-aaf2-b36506ecb980",
+        "source": "Linker",
+        "target": "LocalLinker"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "fcdfb0983d674aa8b17f0c3bfa0e8027": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "yellow",
+        "id": "ParamsType",
+        "label": "ParamsType",
+        "name": "ParamsType",
+        "tooltip": "theano.gof.params_type"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 1075.8500000000001
+       }
+      }
+     },
+     "fe907466d90b4c979aac96acdafc08f7": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "EdgeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "classes": " directed ",
+       "data": {
+        "id": "e9f9e6f2-ffd8-436a-b661-e44d45a9009e",
+        "source": "CAReduce",
+        "target": "Max"
+       },
+       "position": {
+        "x": 0,
+        "y": 0
+       }
+      }
+     },
+     "fee5b74fd8db4035a17e6f7edf1ce6b8": {
+      "model_module": "jupyter-cytoscape",
+      "model_module_version": "^1.0.4",
+      "model_name": "NodeModel",
+      "state": {
+       "_model_module_version": "^1.0.4",
+       "_view_module_version": "^1.0.4",
+       "data": {
+        "color": "pink",
+        "id": "Sequence",
+        "label": "Sequence",
+        "name": "Sequence",
+        "tooltip": "collections.abc"
+       },
+       "position": {
+        "x": 423.275,
+        "y": 4232.85
+       }
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Jupyter notebooks can not only serve as examples, but also as tools to jumpstart development on the codebase.

With a `notebooks/` directory at the root-level of the repo, such notebooks are easy to find (unlike in the PyMC3 repo) and can still be linked into a Sphinx-documentation (using [`nbsphinx_link`](https://github.com/vidartf/nbsphinx-link) as we did [here](https://github.com/michaelosthege/calibr8/blob/master/docs/source/Example_Model_Fitting.nblink)).

### Changes
+ `.vs` cache folder added to gitignore
+ `notebooks/Sandbox*` added to gitignore - this way one can make arbitrary "Sandbox_MyTestingNotebook.ipynb" notebooks that are pleasantly gitignored
+ `Dev_ClassGraph.ipynb` is a notebook for visualizing types and their superclasses, while coloring the nodes in the graph according to the modules.
