### PR TITLE
Use jax.lax.cond for IfElse Op

### DIFF
--- a/tests/sandbox/test_jax.py
+++ b/tests/sandbox/test_jax.py
@@ -472,10 +472,12 @@ def test_jax_ifelse():
 
     compare_jax_and_py(x_fg, [])
 
-    x = theano.ifelse.ifelse(np.array(False), true_vals, false_vals)
-    x_fg = theano.gof.FunctionGraph([], [x])
+    a = tt.dscalar("a")
+    a.tag.test_value = np.array(0.2, dtype=theano.config.floatX)
+    x = theano.ifelse.ifelse(a < 0.5, true_vals, false_vals)
+    x_fg = theano.gof.FunctionGraph([a], [x])  # I.e. False
 
-    compare_jax_and_py(x_fg, [])
+    compare_jax_and_py(x_fg, [get_test_value(i) for i in x_fg.inputs])
 
 
 def test_jax_CAReduce():

--- a/theano/sandbox/jaxify.py
+++ b/theano/sandbox/jaxify.py
@@ -529,10 +529,7 @@ def jax_funcify_IfElse(op):
 
     def ifelse(cond, *args, n_outs=n_outs):
         res = jax.lax.cond(
-            cond,
-            lambda _: args[:n_outs],
-            lambda _: args[n_outs:],
-            operand=None
+            cond, lambda _: args[:n_outs], lambda _: args[n_outs:], operand=None
         )
         return res if n_outs > 1 else res[0]
 

--- a/theano/sandbox/jaxify.py
+++ b/theano/sandbox/jaxify.py
@@ -530,13 +530,11 @@ def jax_funcify_IfElse(op):
     def ifelse(cond, *args, n_outs=n_outs):
         res = jax.lax.cond(
             cond,
-            # lambda _: args[0],
-            # lambda _: args[1],
-            lambda _: jax.lax.cond(n_outs > 1, lambda _: args[:n_outs], lambda _: args[0], operand=None),
-            lambda _: jax.lax.cond(n_outs > 1, lambda _: args[n_outs:], lambda _: args[1], operand=None),
+            lambda _: args[:n_outs],
+            lambda _: args[n_outs:],
             operand=None
         )
-        return res
+        return res if n_outs > 1 else res[0]
 
     return ifelse
 

--- a/theano/sandbox/jaxify.py
+++ b/theano/sandbox/jaxify.py
@@ -528,12 +528,15 @@ def jax_funcify_IfElse(op):
     n_outs = op.n_outs
 
     def ifelse(cond, *args, n_outs=n_outs):
-        if cond:
-            res = args[:n_outs]
-        else:
-            res = args[n_outs:]
-
-        return res if n_outs > 1 else res[0]
+        res = jax.lax.cond(
+            cond,
+            # lambda _: args[0],
+            # lambda _: args[1],
+            lambda _: jax.lax.cond(n_outs > 1, lambda _: args[:n_outs], lambda _: args[0], operand=None),
+            lambda _: jax.lax.cond(n_outs > 1, lambda _: args[n_outs:], lambda _: args[1], operand=None),
+            operand=None
+        )
+        return res
 
     return ifelse
 


### PR DESCRIPTION
~~[WIP, will request review when ready.]~~

Closes #178.

cc @dfm @brandonwillard 

The test fails right now, both for the case with `np.array(True)` value, or `tt.dscalar() < 0.5` (with an input value appropriately passed). I've included (the last lines of) the traceback below, and can say that both cases produce similar error messages.

I'm unsure what we want to do here - it still seems to me that the if and else paths must both return the same dtype, which is not the case here. Am I missing something?

<details>
  <summary>Traceback</summary>

```
During handling of the above exception, another exception occurred:

    def test_jax_ifelse():

        import theano.ifelse

        true_vals = np.r_[1, 2, 3]
        false_vals = np.r_[-1, -2, -3]

        x = theano.ifelse.ifelse(np.array(True), true_vals, false_vals)
        x_fg = theano.gof.FunctionGraph([], [x])

>       compare_jax_and_py(x_fg, [])

test_jax.py:473:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_jax.py:59: in compare_jax_and_py
    jax_res = theano_jax_fn(*inputs)
../../theano/compile/function/types.py:974: in __call__
    if output_subset is None
../../theano/gof/link.py:702: in streamline_default_f
    raise_with_op(node, thunk)
../../theano/gof/link.py:343: in raise_with_op
    raise exc_value.with_traceback(exc_trace)
../../theano/gof/link.py:698: in streamline_default_f
    thunk()
../../theano/sandbox/jax_linker.py:88: in thunk
    for jax_impl_jit in jax_impl_jits
../../theano/sandbox/jax_linker.py:88: in <listcomp>
    for jax_impl_jit in jax_impl_jits
../../theano-venv/lib/python3.7/site-packages/jax/traceback_util.py:133: in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
../../theano-venv/lib/python3.7/site-packages/jax/api.py:223: in f_jitted
    donated_invars=donated_invars)
../../theano-venv/lib/python3.7/site-packages/jax/core.py:1177: in bind
    return call_bind(self, fun, *args, **params)
../../theano-venv/lib/python3.7/site-packages/jax/core.py:1630: in call_bind
    outs = primitive.impl(fun, *args, **params)
../../theano-venv/lib/python3.7/site-packages/jax/interpreters/xla.py:557: in _xla_call_impl
    *unsafe_map(arg_spec, args))
../../theano-venv/lib/python3.7/site-packages/jax/linear_util.py:251: in memoized_fun
    ans = call(fun, *args)
../../theano-venv/lib/python3.7/site-packages/jax/interpreters/xla.py:638: in _xla_callable
    fun, pvals, instantiate=False, stage_out=True, bottom=True)  # type: ignore
../../theano-venv/lib/python3.7/site-packages/jax/interpreters/partial_eval.py:1272: in trace_to_jaxpr
    jaxpr, (out_pvals, consts, env) = fun.call_wrapped(pvals)
../../theano-venv/lib/python3.7/site-packages/jax/linear_util.py:160: in call_wrapped
    ans = self.f(*args, **dict(self.params, **kwargs))
../../theano/sandbox/jaxify.py:180: in jax_func
    return return_func(*func_args)
../../theano/sandbox/jaxify.py:537: in ifelse
    operand=None
../../theano-venv/lib/python3.7/site-packages/jax/_src/lax/control_flow.py:665: in cond
    return _cond(*args, **kwargs)
../../theano-venv/lib/python3.7/site-packages/jax/_src/lax/control_flow.py:695: in _cond
    (true_fun, false_fun), ops_tree, ops_avals)
../../theano-venv/lib/python3.7/site-packages/jax/_src/lax/control_flow.py:2628: in _initial_style_jaxprs_with_common_consts
    _initial_style_open_jaxpr(fun, in_tree, in_avals) for fun in funs])
../../theano-venv/lib/python3.7/site-packages/jax/_src/lax/control_flow.py:2628: in <listcomp>
    _initial_style_open_jaxpr(fun, in_tree, in_avals) for fun in funs])
../../theano-venv/lib/python3.7/site-packages/jax/_src/lax/control_flow.py:2608: in _initial_style_open_jaxpr
    wrapped_fun, in_pvals, instantiate=True, stage_out=False)  # type: ignore
../../theano-venv/lib/python3.7/site-packages/jax/interpreters/partial_eval.py:1272: in trace_to_jaxpr
    jaxpr, (out_pvals, consts, env) = fun.call_wrapped(pvals)
../../theano-venv/lib/python3.7/site-packages/jax/linear_util.py:160: in call_wrapped
    ans = self.f(*args, **dict(self.params, **kwargs))
../../theano/sandbox/jaxify.py:535: in <lambda>
    lambda _: jax.lax.cond(n_outs > 1, lambda _: args[:n_outs], lambda _: args[0], operand=None),
../../theano-venv/lib/python3.7/site-packages/jax/_src/lax/control_flow.py:665: in cond
    return _cond(*args, **kwargs)
../../theano-venv/lib/python3.7/site-packages/jax/_src/lax/control_flow.py:701: in _cond
    false_out_tree, false_jaxpr.out_avals)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

what = 'true_fun and false_fun output', tree1 = PyTreeDef(tuple, [*]), avals1 = [ShapedArray(int64[3])], tree2 = *, avals2 = [ShapedArray(int64[3])]

    def _check_tree_and_avals(what, tree1, avals1, tree2, avals2):
      """Raises TypeError if (tree1, avals1) does not match (tree2, avals2).

      Corresponding `tree` and `avals` must match in the sense that the number of
      leaves in `tree` must be equal to the length of `avals`. `what` will be
      prepended to details of the mismatch in TypeError.
      """
      if tree1 != tree2:
        msg = ("{} must have same type structure, got {} and {}.")
>       raise TypeError(msg.format(what, tree1, tree2))
E       TypeError: true_fun and false_fun output must have same type structure, got PyTreeDef(tuple, [*]) and *.
E       Apply node that caused the error: if{}(TensorConstant{True}, TensorConstant{[1 2 3]}, TensorConstant{[-1 -2 -3]})
E       Toposort index: 0
E       Inputs types: [TensorType(bool, scalar), TensorType(int64, vector), TensorType(int64, vector)]
E       Inputs shapes: []
E       Inputs strides: []
E       Inputs values: []
E       Outputs clients: [['output']]
E
E       Backtrace when the node is created(use Theano flag traceback.limit=N to make it longer):
E         File "/Users/george/Theano-PyMC/theano-venv/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
E           firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
E         File "/Users/george/Theano-PyMC/theano-venv/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
E           res = hook_impl.function(*args)
E         File "/Users/george/Theano-PyMC/theano-venv/lib/python3.7/site-packages/_pytest/python.py", line 184, in pytest_pyfunc_call
E           result = testfunction(**testargs)
E         File "/Users/george/Theano-PyMC/tests/sandbox/test_jax.py", line 470, in test_jax_ifelse
E           x = theano.ifelse.ifelse(np.array(True), true_vals, false_vals)
E         File "/Users/george/Theano-PyMC/theano/ifelse.py", line 410, in ifelse
E           rval = new_ifelse(*ins, **dict(return_list=True))
E         File "/Users/george/Theano-PyMC/theano/gof/op.py", line 642, in __call__
E           node = self.make_node(*inputs, **kwargs)
E         File "/Users/george/Theano-PyMC/theano/ifelse.py", line 197, in make_node
E           return Apply(self, [c] + list(args), [t.type() for t in ts])
E         File "/Users/george/Theano-PyMC/theano/ifelse.py", line 197, in <listcomp>
E           return Apply(self, [c] + list(args), [t.type() for t in ts])
E
E       HINT: Use the Theano flag 'exception_verbosity=high' for a debugprint and storage map footprint of this apply node.
```
</details>