### PR TITLE
Rename ReplacementDidntRemovedError to ReplacementDidNotRemoveError

### DIFF
--- a/theano/gof/__init__.py
+++ b/theano/gof/__init__.py
@@ -48,7 +48,7 @@ from theano.gof.toolbox import (
     NodeFinder,
     NoOutputFromInplace,
     PrintListener,
-    ReplacementDidntRemovedError,
+    ReplacementDidNotRemoveError,
     ReplaceValidate,
     Validator,
 )

--- a/theano/gof/toolbox.py
+++ b/theano/gof/toolbox.py
@@ -22,7 +22,7 @@ class AlreadyThere(Exception):
     """
 
 
-class ReplacementDidntRemovedError(Exception):
+class ReplacementDidNotRemoveError(Exception):
     """
     This exception should be thrown by replace_all_validate_remove
     when an optimization wanted to remove a Variable or a Node from
@@ -621,7 +621,7 @@ class ReplaceValidate(History, Validator):
                         file=out,
                     )
                     print(reason, replacements, file=out)
-                raise ReplacementDidntRemovedError()
+                raise ReplacementDidNotRemoveError()
 
     def __getstate__(self):
         d = self.__dict__.copy()

--- a/theano/tensor/blas.py
+++ b/theano/tensor/blas.py
@@ -150,7 +150,7 @@ from theano.gof import (
     InconsistencyError,
     Op,
     Optimizer,
-    ReplacementDidntRemovedError,
+    ReplacementDidNotRemoveError,
     SequenceDB,
     local_optimizer,
     view_roots,
@@ -1535,7 +1535,7 @@ class GemmOptimizer(Optimizer):
                         # TODO: retry other applications of gemm (see comment
                         # in _gemm_from_node)
                         nb_inconsistency_replace += 1
-                    except ReplacementDidntRemovedError:
+                    except ReplacementDidNotRemoveError:
                         nb_replacement_didn_t_remove += 1
                         self.warned = True
         fgraph.remove_feature(u)


### PR DESCRIPTION
This PR fixes the odd grammar of `ReplacementDidntRemovedError` by changing it to `ReplacementDidNotRemoveError`.