### PR TITLE
Remove Notes section from clip

### DIFF
--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -3759,9 +3759,7 @@ def clip(x, min, max):
     """
     Clip x to be between min and max.
 
-    Notes
-    -----
-    When `x` is equal to the boundaries, the output is considered
+    Note that when `x` is equal to the boundaries, the output is considered
     to be `x`, so at these points, the gradient of the cost wrt the output
     will be propagated to `x`, not to `min` nor `max`. In other words,
     on these points, the gradient wrt `x` will be equal to the gradient wrt


### PR DESCRIPTION
Looks like in 7ef9e747ef17126a46a2a21d55dd7b5881ebd188 the following was added
```diff
+    :note: When `x` is equal to the boundaries, the output is considered
+        to be `x`, so at these points, the gradient will flow through `x`,
+        not through `min` nor `max`.
```
and then in 47bf74270d83f518f2fcf37bfcf93b0fc0db6aba it was changed to
```
Notes
-----
```
which causes a problem when building the PyMC3 docs, see https://github.com/pymc-devs/pymc3/issues/4276#issuecomment-736681131

With the following change, and then installing Theano-PyMC3 locally in my pymc3-dev-py38 environment, the PyMC3 docs build successfully