### PR TITLE
Fix mkl warning in default_blas_ldflags

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,45 +1,60 @@
 """
 Test config options.
 """
+import logging
+from unittest.mock import patch
 
+from theano.configdefaults import default_blas_ldflags
 from theano.configparser import THEANO_FLAGS_DICT, AddConfigVar, ConfigParam
 
 
-class TestConfig:
-    def test_invalid_default(self):
-        # Ensure an invalid default value found in the Theano code only causes
-        # a crash if it is not overridden by the user.
+def test_invalid_default():
+    # Ensure an invalid default value found in the Theano code only causes
+    # a crash if it is not overridden by the user.
 
-        def filter(val):
-            if val == "invalid":
-                raise ValueError()
-            else:
-                return val
+    def filter(val):
+        if val == "invalid":
+            raise ValueError()
+        else:
+            return val
 
-        try:
-            # This should raise a ValueError because the default value is
-            # invalid.
-            AddConfigVar(
-                "T_config.test_invalid_default_a",
-                doc="unittest",
-                configparam=ConfigParam("invalid", filter=filter),
-                in_c_key=False,
-            )
-            raise AssertionError()
-        except ValueError:
-            pass
-
-        THEANO_FLAGS_DICT["T_config.test_invalid_default_b"] = "ok"
-        # This should succeed since we defined a proper value, even
-        # though the default was invalid.
+    try:
+        # This should raise a ValueError because the default value is
+        # invalid.
         AddConfigVar(
-            "T_config.test_invalid_default_b",
+            "T_config.test_invalid_default_a",
             doc="unittest",
             configparam=ConfigParam("invalid", filter=filter),
             in_c_key=False,
         )
+        raise AssertionError()
+    except ValueError:
+        pass
 
-        # Check that the flag has been removed
-        assert "T_config.test_invalid_default_b" not in THEANO_FLAGS_DICT
+    THEANO_FLAGS_DICT["T_config.test_invalid_default_b"] = "ok"
+    # This should succeed since we defined a proper value, even
+    # though the default was invalid.
+    AddConfigVar(
+        "T_config.test_invalid_default_b",
+        doc="unittest",
+        configparam=ConfigParam("invalid", filter=filter),
+        in_c_key=False,
+    )
 
-        # TODO We should remove these dummy options on test exit.
+    # Check that the flag has been removed
+    assert "T_config.test_invalid_default_b" not in THEANO_FLAGS_DICT
+
+    # TODO We should remove these dummy options on test exit.
+
+
+@patch("theano.configdefaults.try_blas_flag", return_value=None)
+@patch("theano.configdefaults.sys")
+def test_default_blas_ldflags(sys_mock, try_blas_flag_mock, caplog):
+
+    sys_mock.version = "3.8.0 | packaged by conda-forge | (default, Nov 22 2019, 19:11:38) \n[GCC 7.3.0]"
+
+    with patch.dict("sys.modules", {"mkl": None}):
+        with caplog.at_level(logging.WARNING):
+            default_blas_ldflags()
+
+    assert "install mkl with" in caplog.text

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -1835,7 +1835,7 @@ def default_blas_ldflags():
         # the fallback and test -lblas could give slow computation, so
         # warn about this.
         for warn in warn_record:
-            _logger.warning(*warn)
+            _logger.warning(warn)
         del warn_record
 
         # Some environment don't have the lib dir in LD_LIBRARY_PATH.


### PR DESCRIPTION
This PR fixes a logger bug in `default_blas_ldflags`.

Closes #205.