### PR TITLE
[WIP] Add py38 to testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: ["3.6", "3.7", "3.8"]
         fast-compile: [0]
         float32: [0]
         part:


### PR DESCRIPTION
WIP PR

Pretty sure this package fails on py38. Been running into this issue locally but now its affecting the ArviZ testing suite. Not sure what to do about it yet but putting up this PR to validate


https://dev.azure.com/ArviZ/ArviZ/_build/results?buildId=3642&view=logs&j=af9a1d3a-ff8f-5483-6823-86518c773a9b&t=fd8e2ff6-2de2-5933-42ea-542f233b6a4d&l=97

![image](https://user-images.githubusercontent.com/7213793/100821174-afdde300-3404-11eb-873a-31db18698bce.png)
