### PR TITLE
Fix JAX list index error in Scan conversion

### DIFF
--- a/theano/sandbox/jaxify.py
+++ b/theano/sandbox/jaxify.py
@@ -481,7 +481,7 @@ def jax_funcify_Scan(op):
             # + inner_in_non_seqs
             inner_in_mit_sot_flatten = []
             for array, index in zip(inner_in_mit_sot, scan_args.mit_sot_in_slices):
-                inner_in_mit_sot_flatten.extend(array[index])
+                inner_in_mit_sot_flatten.extend(array[jnp.array(index)])
 
             inner_scan_inputs = sum(
                 [


### PR DESCRIPTION
This PR fixes a new `jax` list index error that occurs during the `Scan` `Op` conversion.