### PR TITLE
Get rid of singleton design and most module-level variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           if [[ $FAST_COMPILE == "1" ]]; then export THEANO_FLAGS=$THEANO_FLAGS,mode=FAST_COMPILE; fi
           if [[ $FLOAT32 == "1" ]]; then export THEANO_FLAGS=$THEANO_FLAGS,floatX=float32; fi
-          export THEANO_FLAGS=$THEANO_FLAGS,warn.ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,gcc.cxxflags=-pipe
+          export THEANO_FLAGS=$THEANO_FLAGS,warn__ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,gcc__cxxflags=-pipe
           python -m pytest -x -r A --verbose --runslow --cov=theano/ --cov-report=xml:coverage/coverage-${MATRIX_ID}.xml --no-cov-on-fail $PART
         env:
           MATRIX_ID: ${{ steps.matrix-id.outputs.id }}

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -396,7 +396,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
             OpFromGraph,
         )
 
-    @theano.change_flags(compute_test_value="raise")
+    @config.change_flags(compute_test_value="raise")
     def test_compute_test_value(self):
         x = tt.scalar("x")
         x.tag.test_value = np.array(1.0, dtype=config.floatX)

--- a/tests/compile/test_debugmode.py
+++ b/tests/compile/test_debugmode.py
@@ -190,7 +190,7 @@ wb1 = WeirdBrokenOp("times1")
 
 
 @pytest.mark.skipif(
-    not theano.config.cxx, reason="G++ not available, so we need to skip this test."
+    not config.cxx, reason="G++ not available, so we need to skip this test."
 )
 def test_badthunkoutput():
     # Check if the c and python code is consistent.
@@ -200,12 +200,12 @@ def test_badthunkoutput():
     f_good = theano.function(
         [a, b],
         off_by_half(a, b),
-        mode=debugmode.DebugMode(check_c_code=theano.config.cxx),
+        mode=debugmode.DebugMode(check_c_code=config.cxx),
     )
     f_inconsistent = theano.function(
         [a, b],
         inconsistent(a, b),
-        mode=debugmode.DebugMode(check_c_code=theano.config.cxx),
+        mode=debugmode.DebugMode(check_c_code=config.cxx),
     )
 
     # this should evaluate with no error
@@ -283,7 +283,7 @@ def test_badoptimization_opt_err():
     with pytest.raises(
         theano.gof.toolbox.BadOptimization, match=r"insert_bad_dtype"
     ) as einfo:
-        with theano.change_flags(on_opt_error="raise"):
+        with config.change_flags(on_opt_error="raise"):
             f2 = theano.function(
                 [a, b],
                 a + b,
@@ -337,7 +337,7 @@ def test_stochasticoptimization():
 
 
 @pytest.mark.skipif(
-    not theano.config.cxx, reason="G++ not available, so we need to skip this test."
+    not config.cxx, reason="G++ not available, so we need to skip this test."
 )
 def test_just_c_code():
     x = theano.tensor.dvector()
@@ -366,7 +366,7 @@ def test_baddestroymap():
 
 
 @pytest.mark.skipif(
-    not theano.config.cxx, reason="G++ not available, so we need to skip this test."
+    not config.cxx, reason="G++ not available, so we need to skip this test."
 )
 def test_baddestroymap_c():
     x = theano.tensor.dvector()
@@ -420,7 +420,7 @@ class TestViewMap:
         f([1, 5, 1], [3, 4, 2, 1, 4])
 
     @pytest.mark.skipif(
-        not theano.config.cxx, reason="G++ not available, so we need to skip this test."
+        not config.cxx, reason="G++ not available, so we need to skip this test."
     )
     def test_badviewmap_c(self):
         x = theano.tensor.dvector()
@@ -748,7 +748,7 @@ class TestPreallocatedOutput:
 
         f = theano.function([a, b], out, mode=mode)
 
-        if theano.config.cxx:
+        if config.cxx:
             with pytest.raises(debugmode.BadThunkOutput):
                 f(a_val, b_val)
         else:
@@ -779,7 +779,7 @@ class TestPreallocatedOutput:
 
         f = theano.function([a, b], out, mode=mode)
 
-        if theano.config.cxx:
+        if config.cxx:
             with pytest.raises(debugmode.BadThunkOutput):
                 f(a_val, b_val)
         else:

--- a/tests/compile/test_ops.py
+++ b/tests/compile/test_ops.py
@@ -5,7 +5,7 @@ import pytest
 
 import theano
 from tests import unittest_tools as utt
-from theano import change_flags, config, function
+from theano import config, function
 from theano.compile.ops import Rebroadcast, SpecifyShape, as_op, shape, shape_i
 from theano.gof.fg import FunctionGraph
 from theano.tensor.basic import (
@@ -228,11 +228,11 @@ class TestRebroadcast(utt.InferShapeTester):
         )
 
 
-@change_flags(compute_test_value="raise")
+@config.change_flags(compute_test_value="raise")
 def test_nonstandard_shapes():
     a = tensor3(config.floatX)
     a.tag.test_value = np.random.random((2, 3, 4)).astype(config.floatX)
-    b = tensor3(theano.config.floatX)
+    b = tensor3(config.floatX)
     b.tag.test_value = np.random.random((2, 3, 4)).astype(config.floatX)
 
     tl = make_list([a, b])

--- a/tests/gof/test_destroyhandler.py
+++ b/tests/gof/test_destroyhandler.py
@@ -3,7 +3,7 @@ from copy import copy
 import pytest
 
 from tests.unittest_tools import assertFailure_fast
-from theano import change_flags
+from theano import config
 from theano.gof import destroyhandler, graph
 from theano.gof.fg import FunctionGraph, InconsistencyError
 from theano.gof.graph import Apply, Variable
@@ -417,7 +417,7 @@ def test_value_repl():
     assert g.consistent()
 
 
-@change_flags(compute_test_value="off")
+@config.change_flags(compute_test_value="off")
 def test_value_repl_2():
     x, y, z = inputs()
     sy = sigmoid(y)

--- a/tests/gof/test_fg.py
+++ b/tests/gof/test_fg.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from tests.gof.utils import MyVariable, MyVariable2, op1, op2, op3
-from theano import change_flags
+from theano import config
 from theano.gof.fg import FunctionGraph, MissingInputError
 from theano.gof.toolbox import BadOptimization
 
@@ -186,7 +186,7 @@ class TestFunctionGraph:
         assert var5.owner.inputs[1] is var1
         assert (var5.owner, 1) not in fg.get_clients(var2)
 
-    @change_flags(compute_test_value="raise")
+    @config.change_flags(compute_test_value="raise")
     def test_replace_test_value(self):
 
         var1 = MyVariable("var1")

--- a/tests/gof/test_op.py
+++ b/tests/gof/test_op.py
@@ -5,7 +5,6 @@ import theano
 import theano.gof.op as op
 import theano.tensor as tt
 from theano import config, scalar, shared
-from theano.configparser import change_flags
 from theano.gof.graph import Apply, Variable
 from theano.gof.op import Op
 from theano.gof.type import Generic, Type
@@ -133,13 +132,13 @@ class TestOp:
         assert rval == "test Op no input"
 
     @pytest.mark.skipif(
-        not theano.config.cxx, reason="G++ not available, so we need to skip this test."
+        not config.cxx, reason="G++ not available, so we need to skip this test."
     )
     def test_op_struct(self):
         sop = StructOp()
         c = sop(theano.tensor.constant(0))
         mode = None
-        if theano.config.mode == "FAST_COMPILE":
+        if config.mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         f = theano.function([], c, mode=mode)
         rval = f()
@@ -219,7 +218,7 @@ class TestMakeThunk:
         thunk = o.owner.op.make_thunk(
             o.owner, storage_map, compute_map, no_recycling=[]
         )
-        if theano.config.cxx:
+        if config.cxx:
             required = thunk()
             # Check everything went OK
             assert not required  # We provided all inputs
@@ -275,7 +274,7 @@ def test_test_value_shared():
     assert np.all(v == np.zeros((5, 5)))
 
 
-@change_flags(compute_test_value="raise")
+@config.change_flags(compute_test_value="raise")
 def test_test_value_op():
 
     x = tt.log(np.ones((5, 5)))
@@ -284,7 +283,7 @@ def test_test_value_op():
     assert np.allclose(v, np.zeros((5, 5)))
 
 
-@change_flags(compute_test_value="off")
+@config.change_flags(compute_test_value="off")
 def test_get_test_values_no_debugger():
     """Tests that `get_test_values` returns `[]` when debugger is off."""
 
@@ -292,7 +291,7 @@ def test_get_test_values_no_debugger():
     assert op.get_test_values(x) == []
 
 
-@change_flags(compute_test_value="ignore")
+@config.change_flags(compute_test_value="ignore")
 def test_get_test_values_ignore():
     """Tests that `get_test_values` returns `[]` when debugger is set to "ignore" and some values are missing."""
 
@@ -304,7 +303,7 @@ def test_get_test_values_success():
     """Tests that `get_test_values` returns values when available (and the debugger is on)."""
 
     for mode in ["ignore", "warn", "raise"]:
-        with change_flags(compute_test_value=mode):
+        with config.change_flags(compute_test_value=mode):
             x = tt.vector()
             x.tag.test_value = np.zeros((4,), dtype=config.floatX)
             y = np.zeros((5, 5))
@@ -321,7 +320,7 @@ def test_get_test_values_success():
             assert iters == 1
 
 
-@change_flags(compute_test_value="raise")
+@config.change_flags(compute_test_value="raise")
 def test_get_test_values_exc():
     """Tests that `get_test_values` raises an exception when debugger is set to raise and a value is missing."""
 

--- a/tests/gof/test_opt.py
+++ b/tests/gof/test_opt.py
@@ -1,5 +1,6 @@
 import theano.tensor as tt
 from tests.gof.utils import MyType, MyVariable, op1, op2, op3, op4, op5, op6, op_y, op_z
+from theano import config
 from theano.gof.fg import FunctionGraph
 from theano.gof.graph import Apply, Constant
 from theano.gof.op import Op
@@ -10,7 +11,6 @@ from theano.gof.opt import (
     OpSub,
     PatternSub,
     TopoOptimizer,
-    config,
     logging,
     pre_constant_merge,
     pre_greedy_local_optimizer,
@@ -305,12 +305,8 @@ class TestMergeOptimizer:
         x = MyVariable("x")
         y = Constant(MyType(), 2, name="y")
         z = Constant(MyType(), 2, name="z")
-        ctv_backup = config.compute_test_value
-        config.compute_test_value = "off"
-        try:
+        with config.change_flags(compute_test_value="off"):
             e1 = op1(y, z)
-        finally:
-            config.compute_test_value = ctv_backup
         g = FunctionGraph([x, y, z], [e1])
         MergeOptimizer().optimize(g)
         strg = str(g)
@@ -515,7 +511,7 @@ class TestEquilibrium:
         opt.optimize(g)
         assert str(g) == "FunctionGraph(Op2(x, y))"
 
-    @theano.change_flags(on_opt_error="ignore")
+    @config.change_flags(on_opt_error="ignore")
     def test_low_use_ratio(self):
         x, y, z = map(MyVariable, "xyz")
         e = op3(op4(x, y))

--- a/tests/gof/test_types.py
+++ b/tests/gof/test_types.py
@@ -284,6 +284,6 @@ class TestEnumTypes:
         assert val_billion == val_million * 1000
         assert val_two_billions == val_billion * 2
 
-    @theano.change_flags(**{"cmodule__debug": True})
+    @theano.config.change_flags(**{"cmodule__debug": True})
     def test_op_with_cenumtype_debug(self):
         self.test_op_with_cenumtype()

--- a/tests/gpuarray/test_rng_mrg.py
+++ b/tests/gpuarray/test_rng_mrg.py
@@ -7,7 +7,7 @@ from tests import unittest_tools as utt
 from tests.gpuarray.config import mode_with_gpu as mode
 from tests.sandbox.test_rng_mrg import java_samples, rng_mrg_overflow
 from tests.sandbox.test_rng_mrg import test_f16_nonzero as cpu_f16_nonzero
-from theano import change_flags, tensor
+from theano import config, tensor
 from theano.gpuarray.rng_mrg import GPUA_mrg_uniform
 from theano.gpuarray.type import gpuarray_shared_constructor
 from theano.sandbox import rng_mrg
@@ -161,7 +161,7 @@ def test_overflow_gpu_new_backend():
 
 
 def test_validate_input_types_gpuarray_backend():
-    with change_flags(compute_test_value="raise"):
+    with config.change_flags(compute_test_value="raise"):
         rstate = np.zeros((7, 6), dtype="int32")
         rstate = gpuarray_shared_constructor(rstate)
         rng_mrg.mrg_uniform.new(rstate, ndim=None, dtype="float32", size=(3,))

--- a/tests/gpuarray/test_subtensor.py
+++ b/tests/gpuarray/test_subtensor.py
@@ -130,7 +130,7 @@ def test_advinc_subtensor1_dtype():
         assert np.allclose(rval, rep)
 
 
-@theano.change_flags(deterministic="more")
+@theano.config.change_flags(deterministic="more")
 def test_deterministic_flag():
     shp = (3, 4)
     for dtype1, dtype2 in [("float32", "int8")]:

--- a/tests/sandbox/test_jax.py
+++ b/tests/sandbox/test_jax.py
@@ -14,7 +14,7 @@ from theano.gof.op import get_test_value  # noqa: E402
 
 @pytest.fixture(scope="module", autouse=True)
 def set_theano_flags():
-    with theano.change_flags(cxx="", compute_test_value="ignore"):
+    with theano.config.change_flags(cxx="", compute_test_value="ignore"):
         yield
 
 
@@ -136,7 +136,7 @@ def test_jax_compile_ops():
 
     compare_jax_and_py(x_fg, [])
 
-    with theano.change_flags(compute_test_value="off"):
+    with theano.config.change_flags(compute_test_value="off"):
         x = theano.compile.ops.SpecifyShape()(tt.as_tensor_variable(x_np), (2, 3))
         x_fg = theano.gof.FunctionGraph([], [x])
 
@@ -151,7 +151,7 @@ def test_jax_compile_ops():
 
     compare_jax_and_py(x_fg, [])
 
-    with theano.change_flags(compute_test_value="off"):
+    with theano.config.change_flags(compute_test_value="off"):
         x = theano.compile.ops.Rebroadcast((0, True), (1, False), (2, False))(
             tt.as_tensor_variable(x_np)
         )

--- a/tests/sandbox/test_rng_mrg.py
+++ b/tests/sandbox/test_rng_mrg.py
@@ -7,7 +7,7 @@ import pytest
 
 import theano
 from tests import unittest_tools as utt
-from theano import change_flags, config, tensor
+from theano import config, tensor
 from theano.sandbox import rng_mrg
 from theano.sandbox.rng_mrg import MRG_RandomStreams
 
@@ -78,18 +78,13 @@ def test_consistency_randomstreams():
 
 
 def test_get_substream_rstates():
-    try:
-        orig = theano.config.compute_test_value
-        theano.config.compute_test_value = "raise"
+    with config.change_flags(compute_test_value="raise"):
         n_streams = 100
 
         dtype = "float32"
         rng = MRG_RandomStreams(np.random.randint(2147462579))
 
         rng.get_substream_rstates(n_streams, dtype)
-
-    finally:
-        theano.config.compute_test_value = orig
 
 
 def test_consistency_cpu_serial():
@@ -949,7 +944,7 @@ def test_overflow_cpu():
     # run with THEANO_FLAGS=mode=FAST_RUN,device=cpu,floatX=float32
     rng = MRG_RandomStreams(np.random.randint(1234))
     fct = rng.uniform
-    with change_flags(compute_test_value="off"):
+    with config.change_flags(compute_test_value="off"):
         # should raise error as the size overflows
         sizes = [
             (2 ** 31,),

--- a/tests/scalar/test_type.py
+++ b/tests/scalar/test_type.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from theano import change_flags
+from theano import config
 from theano.scalar.basic import (
     IntDiv,
     Scalar,
@@ -33,7 +33,7 @@ def test_div_types():
 
 def test_filter_float_subclass():
     """Make sure `Scalar.filter` can handle `float` subclasses."""
-    with change_flags(floatX="float64"):
+    with config.change_flags(floatX="float64"):
         test_type = Scalar("float64")
 
         nan = np.array([np.nan], dtype="float64")[0]
@@ -42,7 +42,7 @@ def test_filter_float_subclass():
         filtered_nan = test_type.filter(nan)
         assert isinstance(filtered_nan, float)
 
-    with change_flags(floatX="float32"):
+    with config.change_flags(floatX="float32"):
         # Try again, except this time `nan` isn't a `float`
         test_type = Scalar("float32")
 

--- a/tests/tensor/_test_mpi_roundtrip.py
+++ b/tests/tensor/_test_mpi_roundtrip.py
@@ -7,7 +7,7 @@ import numpy as np
 from mpi4py import MPI
 
 import theano
-from theano.configparser import change_flags
+from theano import config
 from theano.gof.sched import sort_schedule_fn
 from theano.tensor.io import mpi_cmps, recv, send
 
@@ -31,7 +31,7 @@ dtype = "float32"
 scheduler = sort_schedule_fn(*mpi_cmps)
 mode = theano.Mode(optimizer=None, linker=theano.OpWiseCLinker(schedule=scheduler))
 
-with change_flags(compute_test_value="off"):
+with config.change_flags(compute_test_value="off"):
     if rank == 0:
         x = theano.tensor.matrix("x", dtype=dtype)
         y = x + 1

--- a/tests/tensor/nnet/test_abstract_conv.py
+++ b/tests/tensor/nnet/test_abstract_conv.py
@@ -3,7 +3,7 @@ import pytest
 
 import theano
 from tests import unittest_tools as utt
-from theano import change_flags, tensor
+from theano import config, tensor
 from theano.gof.opt import check_stack_trace
 from theano.tensor.nnet import abstract_conv as conv
 from theano.tensor.nnet import conv2d_transpose, corr, corr3d
@@ -295,7 +295,7 @@ class TestAssertConvShape:
 
 
 class TestAssertShape:
-    @change_flags(conv__assert_shape=True)
+    @config.change_flags(conv__assert_shape=True)
     def test_basic(self):
         x = tensor.tensor4()
         s1 = tensor.iscalar()
@@ -318,7 +318,7 @@ class TestAssertShape:
         with pytest.raises(AssertionError):
             f(v, 7, 7)
 
-    @change_flags(conv__assert_shape=True)
+    @config.change_flags(conv__assert_shape=True)
     def test_shape_check_conv2d(self):
         input = tensor.tensor4()
         filters = tensor.tensor4()
@@ -340,8 +340,8 @@ class TestAssertShape:
                 np.zeros((7, 5, 2, 2), dtype="float32"),
             )
 
-    @change_flags(conv__assert_shape=True)
-    @pytest.mark.skipif(theano.config.cxx == "", reason="test needs cxx")
+    @config.change_flags(conv__assert_shape=True)
+    @pytest.mark.skipif(config.cxx == "", reason="test needs cxx")
     def test_shape_check_conv3d(self):
         input = tensor.tensor5()
         filters = tensor.tensor5()
@@ -363,7 +363,7 @@ class TestAssertShape:
                 np.zeros((7, 5, 2, 2, 2), dtype="float32"),
             )
 
-    @change_flags(conv__assert_shape=True)
+    @config.change_flags(conv__assert_shape=True)
     def test_shape_check_conv2d_grad_wrt_inputs(self):
         output_grad = tensor.tensor4()
         filters = tensor.tensor4()
@@ -382,8 +382,8 @@ class TestAssertShape:
                 np.zeros((7, 6, 3, 3), dtype="float32"),
             )
 
-    @change_flags(conv__assert_shape=True)
-    @pytest.mark.skipif(theano.config.cxx == "", reason="test needs cxx")
+    @config.change_flags(conv__assert_shape=True)
+    @pytest.mark.skipif(config.cxx == "", reason="test needs cxx")
     def test_shape_check_conv3d_grad_wrt_inputs(self):
         output_grad = tensor.tensor5()
         filters = tensor.tensor5()
@@ -402,7 +402,7 @@ class TestAssertShape:
                 np.zeros((7, 6, 3, 3, 3), dtype="float32"),
             )
 
-    @change_flags(conv__assert_shape=True)
+    @config.change_flags(conv__assert_shape=True)
     def test_shape_check_conv2d_grad_wrt_weights(self):
         input = tensor.tensor4()
         output_grad = tensor.tensor4()
@@ -421,8 +421,8 @@ class TestAssertShape:
                 np.zeros((3, 7, 5, 9), dtype="float32"),
             )
 
-    @change_flags(conv__assert_shape=True)
-    @pytest.mark.skipif(theano.config.cxx == "", reason="test needs cxx")
+    @config.change_flags(conv__assert_shape=True)
+    @pytest.mark.skipif(config.cxx == "", reason="test needs cxx")
     def test_shape_check_conv3d_grad_wrt_weights(self):
         input = tensor.tensor5()
         output_grad = tensor.tensor5()
@@ -757,7 +757,7 @@ class BaseTestConv:
 class BaseTestConv2d(BaseTestConv):
     @classmethod
     def setup_class(cls):
-        # This tests can run even when theano.config.blas__ldflags is empty.
+        # This tests can run even when config.blas__ldflags is empty.
         cls.inputs_shapes = [
             (8, 1, 6, 6),
             (8, 1, 8, 8),
@@ -929,13 +929,13 @@ class BaseTestConv2d(BaseTestConv):
 
 
 @pytest.mark.skipif(
-    not theano.config.cxx or theano.config.mode == "FAST_COMPILE",
+    not config.cxx or config.mode == "FAST_COMPILE",
     reason="Need blas to test conv2d",
 )
 class TestCorrConv2d(BaseTestConv2d):
     @classmethod
     def setup_class(cls):
-        # This tests can run even when theano.config.blas__ldflags is empty.
+        # This tests can run even when config.blas__ldflags is empty.
         super().setup_class()
 
     def run_test_case(self, i, f, s, b, flip, provide_shape, fd=(1, 1)):
@@ -1019,14 +1019,13 @@ class TestCorrConv2d(BaseTestConv2d):
 
 
 @pytest.mark.skipif(
-    theano.config.cxx == ""
-    or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
+    config.cxx == "" or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
     reason="SciPy and cxx needed",
 )
 class TestAbstractConvNoOptim(BaseTestConv2d):
     @classmethod
     def setup_class(cls):
-        # This tests can run even when theano.config.blas__ldflags is empty.
+        # This tests can run even when config.blas__ldflags is empty.
         super().setup_class()
         cls.inputs_shapes = [(8, 1, 6, 6)]
         cls.filters_shapes = [(5, 1, 2, 2)]
@@ -1122,7 +1121,7 @@ class TestAbstractConvNoOptim(BaseTestConv2d):
 class BaseTestConv3d(BaseTestConv):
     @classmethod
     def setup_class(cls):
-        # This tests can run even when theano.config.blas__ldflags is empty.
+        # This tests can run even when config.blas__ldflags is empty.
         cls.inputs_shapes = [
             (2, 1, 5, 5, 5),
             (1, 2, 7, 5, 6),
@@ -1290,18 +1289,18 @@ class BaseTestConv3d(BaseTestConv):
 
 
 @pytest.mark.skipif(
-    not theano.config.cxx or theano.config.mode == "FAST_COMPILE",
+    not config.cxx or config.mode == "FAST_COMPILE",
     reason="Need blas to test conv3d",
 )
 class TestCorrConv3d(BaseTestConv3d):
     @classmethod
     def setup_class(cls):
-        # This tests can run even when theano.config.blas__ldflags is empty.
+        # This tests can run even when config.blas__ldflags is empty.
         super().setup_class()
 
     def run_test_case(self, i, f, s, b, flip, provide_shape, fd=(1, 1, 1)):
         o = self.get_output_shape(i, f, s, b, fd)
-        # This test can run even when theano.config.blas__ldflags is empty.
+        # This test can run even when config.blas__ldflags is empty.
         self.run_fwd(
             inputs_shape=i,
             filters_shape=f,
@@ -1344,7 +1343,7 @@ class TestCorrConv3d(BaseTestConv3d):
     def run_test_case_gi(
         self, i, f, o, s, b, flip, provide_shape, fd=(1, 1, 1), expect_error=False
     ):
-        # This test can run even when theano.config.blas__ldflags is empty.
+        # This test can run even when config.blas__ldflags is empty.
         if not expect_error:
             self.run_gradinput(
                 inputs_shape=i,
@@ -1561,13 +1560,13 @@ class TestConvTypes:
 
 
 class TestBilinearUpsampling:
-    # If theano.config.blas__ldflags is empty, Theano will use
+    # If config.blas__ldflags is empty, Theano will use
     # a NumPy C implementation of [sd]gemm_.
     compile_mode = theano.compile.mode.get_default_mode()
-    if theano.config.mode == "FAST_COMPILE":
+    if config.mode == "FAST_COMPILE":
         compile_mode = compile_mode.excluding("conv_gemm")
         compile_mode = compile_mode.excluding("AbstractConvCheck")
-    elif not theano.config.cxx:
+    elif not config.cxx:
         compile_mode = compile_mode.excluding("AbstractConvCheck")
 
     def numerical_kernel_1D(self, ratio):
@@ -1708,7 +1707,7 @@ class TestBilinearUpsampling:
         # when using 1D kernels for some upsampling ratios.
 
         # upsampling for a ratio of two
-        input_x = np.array([[[[1, 2], [3, 4]]]], dtype=theano.config.floatX)
+        input_x = np.array([[[[1, 2], [3, 4]]]], dtype=config.floatX)
 
         for ratio in [2, 3, 4, 5, 6, 7, 8, 9]:
             bilin_mat = bilinear_upsampling(
@@ -1729,7 +1728,7 @@ class TestBilinearUpsampling:
         # without giving batch_size and num_input_channels
 
         # upsampling for a ratio of two
-        input_x = np.array([[[[1, 2], [3, 4]]]], dtype=theano.config.floatX)
+        input_x = np.array([[[[1, 2], [3, 4]]]], dtype=config.floatX)
 
         for ratio in [2, 3]:
             for use_1D_kernel in [True, False]:
@@ -1751,7 +1750,7 @@ class TestBilinearUpsampling:
         # 1D and 2D kernels will generate the same result.
 
         # checking upsampling with ratio 5
-        input_x = np.random.rand(5, 4, 6, 7).astype(theano.config.floatX)
+        input_x = np.random.rand(5, 4, 6, 7).astype(config.floatX)
         mat_1D = bilinear_upsampling(
             input=input_x,
             ratio=5,
@@ -1771,7 +1770,7 @@ class TestBilinearUpsampling:
         utt.assert_allclose(f_1D(), f_2D(), rtol=1e-06)
 
         # checking upsampling with ratio 8
-        input_x = np.random.rand(12, 11, 10, 7).astype(theano.config.floatX)
+        input_x = np.random.rand(12, 11, 10, 7).astype(config.floatX)
         mat_1D = bilinear_upsampling(
             input=input_x,
             ratio=8,
@@ -1796,7 +1795,7 @@ class TestBilinearUpsampling:
         """
         input_x = np.array(
             [[[1, 2], [3, 4]], [[5, 6], [7, 8]], [[9, 10], [11, 12]]], ndmin=4
-        ).astype(theano.config.floatX)
+        ).astype(config.floatX)
         up_x = bilinear_upsampling(
             input=input_x, frac_ratio=((7, 4), (5, 3)), use_1D_kernel=False
         )
@@ -1823,12 +1822,12 @@ class TestBilinearUpsampling:
                     ],
                 ]
             ]
-        ).astype(theano.config.floatX)
+        ).astype(config.floatX)
         f_up_x = theano.function([], up_x, mode=self.compile_mode)
         utt.assert_allclose(f_up_x(), num_up_x, rtol=1e-6)
 
     def test_fractional_bilinear_upsampling_shape(self):
-        x = np.random.rand(1, 1, 200, 200).astype(theano.config.floatX)
+        x = np.random.rand(1, 1, 200, 200).astype(config.floatX)
         resize = (24, 20)
         z = bilinear_upsampling(
             tensor.as_tensor_variable(x), frac_ratio=resize, use_1D_kernel=False
@@ -1840,7 +1839,7 @@ class TestBilinearUpsampling:
 class TestConv2dTranspose:
     mode = None
 
-    @pytest.mark.skipif(theano.config.cxx == "", reason="Test needs cxx")
+    @pytest.mark.skipif(config.cxx == "", reason="Test needs cxx")
     def test_interface(self):
         # Test conv2d_transpose wrapper.
         #
@@ -1848,7 +1847,7 @@ class TestConv2dTranspose:
         # axes expected by the function produces the correct
         # output shape.
         mode = self.mode
-        if theano.config.mode == "FAST_COMPILE":
+        if config.mode == "FAST_COMPILE":
             mode = (
                 theano.compile.get_mode(mode)
                 .excluding("conv_gemm")
@@ -1888,7 +1887,7 @@ class TestConv2dTranspose:
 
 
 @pytest.mark.skipif(
-    not theano.config.cxx or theano.config.mode == "FAST_COMPILE",
+    not config.cxx or config.mode == "FAST_COMPILE",
     reason="Need blas to test conv3d",
 )
 class TestConv2dGrads:
@@ -1905,8 +1904,8 @@ class TestConv2dGrads:
         self.output_grad = theano.tensor.tensor4()
         self.output_grad_wrt = theano.tensor.tensor4()
 
-        self.x = theano.tensor.tensor4("x", theano.config.floatX)  # inputs
-        self.w = theano.tensor.tensor4("w", theano.config.floatX)  # filter weights
+        self.x = theano.tensor.tensor4("x", config.floatX)  # inputs
+        self.w = theano.tensor.tensor4("w", config.floatX)  # filter weights
 
     def test_conv2d_grad_wrt_inputs(self):
         # Compares calculated abstract grads wrt inputs with the fwd grads
@@ -1919,11 +1918,11 @@ class TestConv2dGrads:
                 for ss in self.subsamples:
                     for ff in self.filter_flip:
                         input_val = self.random_stream.random_sample(in_shape).astype(
-                            theano.config.floatX
+                            config.floatX
                         )
                         filter_val = self.random_stream.random_sample(
                             fltr_shape
-                        ).astype(theano.config.floatX)
+                        ).astype(config.floatX)
                         out_grad_shape = (
                             theano.tensor.nnet.abstract_conv.get_conv_output_shape(
                                 image_shape=in_shape,
@@ -1934,7 +1933,7 @@ class TestConv2dGrads:
                         )
                         out_grad_val = self.random_stream.random_sample(
                             out_grad_shape
-                        ).astype(theano.config.floatX)
+                        ).astype(config.floatX)
                         conv_out = theano.tensor.nnet.conv2d(
                             self.x,
                             filters=self.w,
@@ -1985,11 +1984,11 @@ class TestConv2dGrads:
                 for ss in self.subsamples:
                     for ff in self.filter_flip:
                         input_val = self.random_stream.random_sample(in_shape).astype(
-                            theano.config.floatX
+                            config.floatX
                         )
                         filter_val = self.random_stream.random_sample(
                             fltr_shape
-                        ).astype(theano.config.floatX)
+                        ).astype(config.floatX)
                         out_grad_shape = (
                             theano.tensor.nnet.abstract_conv.get_conv_output_shape(
                                 image_shape=in_shape,
@@ -2000,7 +1999,7 @@ class TestConv2dGrads:
                         )
                         out_grad_val = self.random_stream.random_sample(
                             out_grad_shape
-                        ).astype(theano.config.floatX)
+                        ).astype(config.floatX)
                         conv_out = theano.tensor.nnet.conv2d(
                             self.x,
                             filters=self.w,
@@ -2040,8 +2039,7 @@ class TestConv2dGrads:
 
 
 @pytest.mark.skipif(
-    theano.config.cxx == ""
-    or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
+    config.cxx == "" or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
     reason="SciPy and cxx needed",
 )
 class TestGroupedConvNoOptim:
@@ -2079,8 +2077,8 @@ class TestGroupedConvNoOptim:
         for imshp, kshp, groups in zip(
             self.img_shape, self.kern_shape, self.num_groups
         ):
-            img = np.random.random(imshp).astype(theano.config.floatX)
-            kern = np.random.random(kshp).astype(theano.config.floatX)
+            img = np.random.random(imshp).astype(config.floatX)
+            kern = np.random.random(kshp).astype(config.floatX)
             split_imgs = np.split(img, groups, axis=1)
             split_kern = np.split(kern, groups, axis=0)
 
@@ -2133,8 +2131,8 @@ class TestGroupedConvNoOptim:
         for imshp, kshp, tshp, groups in zip(
             self.img_shape, self.kern_shape, self.top_shape, self.num_groups
         ):
-            img = np.random.random(imshp).astype(theano.config.floatX)
-            top = np.random.random(tshp).astype(theano.config.floatX)
+            img = np.random.random(imshp).astype(config.floatX)
+            top = np.random.random(tshp).astype(config.floatX)
             split_imgs = np.split(img, groups, axis=1)
             split_top = np.split(top, groups, axis=1)
 
@@ -2196,8 +2194,8 @@ class TestGroupedConvNoOptim:
         for imshp, kshp, tshp, groups in zip(
             self.img_shape, self.kern_shape, self.top_shape, self.num_groups
         ):
-            kern = np.random.random(kshp).astype(theano.config.floatX)
-            top = np.random.random(tshp).astype(theano.config.floatX)
+            kern = np.random.random(kshp).astype(config.floatX)
+            top = np.random.random(tshp).astype(config.floatX)
             split_kerns = np.split(kern, groups, axis=0)
             split_top = np.split(top, groups, axis=1)
 
@@ -2251,8 +2249,7 @@ class TestGroupedConvNoOptim:
 
 
 @pytest.mark.skipif(
-    theano.config.cxx == ""
-    or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
+    config.cxx == "" or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
     reason="SciPy and cxx needed",
 )
 class TestGroupedConv3dNoOptim(TestGroupedConvNoOptim):
@@ -2315,7 +2312,7 @@ class TestSeparableConv:
                     ],
                 ]
             ]
-        ).astype(theano.config.floatX)
+        ).astype(config.floatX)
 
         self.depthwise_filter = np.array(
             [
@@ -2324,11 +2321,11 @@ class TestSeparableConv:
                 [[[7, 4, 7], [5, 3, 3], [1, 3, 1]]],
                 [[[4, 4, 4], [2, 4, 6], [0, 0, 7]]],
             ]
-        ).astype(theano.config.floatX)
+        ).astype(config.floatX)
 
         self.pointwise_filter = np.array(
             [[[[4]], [[1]], [[3]], [[5]]], [[[2]], [[1]], [[2]], [[8]]]]
-        ).astype(theano.config.floatX)
+        ).astype(config.floatX)
 
         self.precomp_output_valid = np.array(
             [
@@ -2337,7 +2334,7 @@ class TestSeparableConv:
                     [[1532, 1410, 1259], [1522, 1346, 1314], [1379, 1192, 1286]],
                 ]
             ]
-        ).astype(theano.config.floatX)
+        ).astype(config.floatX)
 
         self.precomp_output_full = np.array(
             [
@@ -2358,9 +2355,9 @@ class TestSeparableConv:
                     ],
                 ]
             ]
-        ).astype(theano.config.floatX)
+        ).astype(config.floatX)
 
-    @pytest.mark.skipif(theano.config.cxx == "", reason="test needs cxx")
+    @pytest.mark.skipif(config.cxx == "", reason="test needs cxx")
     def test_interface2d(self):
         x_sym = theano.tensor.tensor4("x")
         dfilter_sym = theano.tensor.tensor4("d")
@@ -2417,7 +2414,7 @@ class TestSeparableConv:
         top = fun(self.x[:, :, :3, :3], self.depthwise_filter, self.pointwise_filter)
         utt.assert_allclose(top, self.precomp_output_full)
 
-    @pytest.mark.skipif(theano.config.cxx == "", reason="test needs cxx")
+    @pytest.mark.skipif(config.cxx == "", reason="test needs cxx")
     def test_interface3d(self):
         # Expand the filter along the depth
         x = np.tile(np.expand_dims(self.x, axis=2), (1, 1, 5, 1, 1))
@@ -2491,8 +2488,7 @@ class TestSeparableConv:
 
 
 @pytest.mark.skipif(
-    theano.config.cxx == ""
-    or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
+    config.cxx == "" or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
     reason="SciPy and cxx needed",
 )
 class TestUnsharedConv:
@@ -2526,7 +2522,7 @@ class TestUnsharedConv:
         self.ref_mode = "FAST_RUN"
 
     def test_fwd(self):
-        tensor6 = theano.tensor.TensorType(theano.config.floatX, (False,) * 6)
+        tensor6 = theano.tensor.TensorType(config.floatX, (False,) * 6)
         img_sym = theano.tensor.tensor4("img")
         kern_sym = tensor6("kern")
         ref_kern_sym = theano.tensor.tensor4("ref_kern")
@@ -2539,8 +2535,8 @@ class TestUnsharedConv:
             self.num_groups,
             self.verify_flags,
         ):
-            img = np.random.random(imshp).astype(theano.config.floatX)
-            kern = np.random.random(kshp).astype(theano.config.floatX)
+            img = np.random.random(imshp).astype(config.floatX)
+            kern = np.random.random(kshp).astype(config.floatX)
 
             unshared_conv_op = self.conv2d(
                 border_mode=mode,
@@ -2599,8 +2595,8 @@ class TestUnsharedConv:
             self.num_groups,
             self.verify_flags,
         ):
-            img = np.random.random(imshp).astype(theano.config.floatX)
-            top = np.random.random(topshp).astype(theano.config.floatX)
+            img = np.random.random(imshp).astype(config.floatX)
+            top = np.random.random(topshp).astype(config.floatX)
 
             unshared_conv_op = self.conv2d_gradw(
                 border_mode=mode,
@@ -2653,7 +2649,7 @@ class TestUnsharedConv:
                 utt.verify_grad(conv_gradweight, [img, top], mode=self.mode, eps=1)
 
     def test_gradinput(self):
-        tensor6 = theano.tensor.TensorType(theano.config.floatX, (False,) * 6)
+        tensor6 = theano.tensor.TensorType(config.floatX, (False,) * 6)
         kern_sym = tensor6("kern")
         top_sym = theano.tensor.tensor4("top")
         ref_kern_sym = theano.tensor.tensor4("ref_kern")
@@ -2669,8 +2665,8 @@ class TestUnsharedConv:
         ):
             single_kshp = kshp[:1] + kshp[3:]
 
-            kern = np.random.random(kshp).astype(theano.config.floatX)
-            top = np.random.random(topshp).astype(theano.config.floatX)
+            kern = np.random.random(kshp).astype(config.floatX)
+            top = np.random.random(topshp).astype(config.floatX)
 
             unshared_conv_op = self.conv2d_gradi(
                 border_mode=mode,
@@ -2743,8 +2739,7 @@ class TestAsymmetricPadding:
     border_mode = [((1, 2), (2, 1)), ((1, 1), (0, 3)), ((2, 1), (0, 0))]
 
     @pytest.mark.skipif(
-        theano.config.cxx == ""
-        or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
+        config.cxx == "" or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
         reason="SciPy and cxx needed",
     )
     def test_fwd(self):
@@ -2752,8 +2747,8 @@ class TestAsymmetricPadding:
         kern_sym = theano.tensor.tensor4("kern")
 
         for imshp, kshp, pad in zip(self.img_shape, self.kern_shape, self.border_mode):
-            img = np.random.random(imshp).astype(theano.config.floatX)
-            kern = np.random.random(kshp).astype(theano.config.floatX)
+            img = np.random.random(imshp).astype(config.floatX)
+            kern = np.random.random(kshp).astype(config.floatX)
 
             asymmetric_conv_op = self.conv2d(
                 border_mode=pad, subsample=(1, 1), filter_dilation=(1, 1)
@@ -2783,7 +2778,7 @@ class TestAsymmetricPadding:
                 imshp[3] + pad[1][0] + pad[1][1],
             )
 
-            exp_img = np.zeros(exp_imshp, dtype=theano.config.floatX)
+            exp_img = np.zeros(exp_imshp, dtype=config.floatX)
             exp_img[
                 :, :, pad[0][0] : imshp[2] + pad[0][0], pad[1][0] : imshp[3] + pad[1][0]
             ] = img
@@ -2794,8 +2789,7 @@ class TestAsymmetricPadding:
             utt.verify_grad(asymmetric_conv_op, [img, kern], mode=self.mode, eps=1)
 
     @pytest.mark.skipif(
-        theano.config.cxx == ""
-        or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
+        config.cxx == "" or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
         reason="SciPy and cxx needed",
     )
     def test_gradweight(self):
@@ -2805,8 +2799,8 @@ class TestAsymmetricPadding:
         for imshp, kshp, topshp, pad in zip(
             self.img_shape, self.kern_shape, self.topgrad_shape, self.border_mode
         ):
-            img = np.random.random(imshp).astype(theano.config.floatX)
-            top = np.random.random(topshp).astype(theano.config.floatX)
+            img = np.random.random(imshp).astype(config.floatX)
+            top = np.random.random(topshp).astype(config.floatX)
 
             asymmetric_conv_op = self.conv2d_gradw(
                 border_mode=pad, subsample=(1, 1), filter_dilation=(1, 1)
@@ -2836,7 +2830,7 @@ class TestAsymmetricPadding:
                 imshp[3] + pad[1][0] + pad[1][1],
             )
 
-            exp_img = np.zeros(exp_imshp, dtype=theano.config.floatX)
+            exp_img = np.zeros(exp_imshp, dtype=config.floatX)
             exp_img[
                 :, :, pad[0][0] : imshp[2] + pad[0][0], pad[1][0] : imshp[3] + pad[1][0]
             ] = img
@@ -2852,8 +2846,7 @@ class TestAsymmetricPadding:
             utt.verify_grad(conv_gradweight, [img, top], mode=self.mode, eps=1)
 
     @pytest.mark.skipif(
-        theano.config.cxx == ""
-        or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
+        config.cxx == "" or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
         reason="SciPy and cxx needed",
     )
     def test_gradinput(self):
@@ -2863,8 +2856,8 @@ class TestAsymmetricPadding:
         for imshp, kshp, topshp, pad in zip(
             self.img_shape, self.kern_shape, self.topgrad_shape, self.border_mode
         ):
-            kern = np.random.random(kshp).astype(theano.config.floatX)
-            top = np.random.random(topshp).astype(theano.config.floatX)
+            kern = np.random.random(kshp).astype(config.floatX)
+            top = np.random.random(topshp).astype(config.floatX)
 
             asymmetric_conv_op = self.conv2d_gradi(
                 border_mode=pad, subsample=(1, 1), filter_dilation=(1, 1)
@@ -2916,9 +2909,9 @@ class TestCausalConv:
             [[2, 5, 8, 5, 5], [1, 3, 0, 7, 9]],
             [[7, 0, 7, 1, 0], [0, 1, 4, 7, 2]],
         ]
-    ).astype(theano.config.floatX)
+    ).astype(config.floatX)
     kern = np.array([[[5, 3, 1], [3, 1, 0]], [[6, 4, 9], [2, 2, 7]]]).astype(
-        theano.config.floatX
+        config.floatX
     )
     dilation = 2
     precomp_top = np.array(
@@ -2927,11 +2920,10 @@ class TestCausalConv:
             [[13, 34, 47, 64, 78], [14, 36, 58, 70, 105]],
             [[35, 3, 68, 27, 38], [42, 2, 78, 22, 103]],
         ]
-    ).astype(theano.config.floatX)
+    ).astype(config.floatX)
 
     @pytest.mark.skipif(
-        theano.config.cxx == ""
-        or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
+        config.cxx == "" or not theano.tensor.nnet.abstract_conv.imported_scipy_signal,
         reason="SciPy and cxx needed",
     )
     def test_interface(self):

--- a/tests/tensor/nnet/test_abstract_conv.py
+++ b/tests/tensor/nnet/test_abstract_conv.py
@@ -295,7 +295,7 @@ class TestAssertConvShape:
 
 
 class TestAssertShape:
-    @change_flags([("conv__assert_shape", True)])
+    @change_flags(conv__assert_shape=True)
     def test_basic(self):
         x = tensor.tensor4()
         s1 = tensor.iscalar()
@@ -318,7 +318,7 @@ class TestAssertShape:
         with pytest.raises(AssertionError):
             f(v, 7, 7)
 
-    @change_flags([("conv__assert_shape", True)])
+    @change_flags(conv__assert_shape=True)
     def test_shape_check_conv2d(self):
         input = tensor.tensor4()
         filters = tensor.tensor4()
@@ -340,7 +340,7 @@ class TestAssertShape:
                 np.zeros((7, 5, 2, 2), dtype="float32"),
             )
 
-    @change_flags([("conv__assert_shape", True)])
+    @change_flags(conv__assert_shape=True)
     @pytest.mark.skipif(theano.config.cxx == "", reason="test needs cxx")
     def test_shape_check_conv3d(self):
         input = tensor.tensor5()
@@ -363,7 +363,7 @@ class TestAssertShape:
                 np.zeros((7, 5, 2, 2, 2), dtype="float32"),
             )
 
-    @change_flags([("conv__assert_shape", True)])
+    @change_flags(conv__assert_shape=True)
     def test_shape_check_conv2d_grad_wrt_inputs(self):
         output_grad = tensor.tensor4()
         filters = tensor.tensor4()
@@ -382,7 +382,7 @@ class TestAssertShape:
                 np.zeros((7, 6, 3, 3), dtype="float32"),
             )
 
-    @change_flags([("conv__assert_shape", True)])
+    @change_flags(conv__assert_shape=True)
     @pytest.mark.skipif(theano.config.cxx == "", reason="test needs cxx")
     def test_shape_check_conv3d_grad_wrt_inputs(self):
         output_grad = tensor.tensor5()
@@ -402,7 +402,7 @@ class TestAssertShape:
                 np.zeros((7, 6, 3, 3, 3), dtype="float32"),
             )
 
-    @change_flags([("conv__assert_shape", True)])
+    @change_flags(conv__assert_shape=True)
     def test_shape_check_conv2d_grad_wrt_weights(self):
         input = tensor.tensor4()
         output_grad = tensor.tensor4()
@@ -421,7 +421,7 @@ class TestAssertShape:
                 np.zeros((3, 7, 5, 9), dtype="float32"),
             )
 
-    @change_flags([("conv__assert_shape", True)])
+    @change_flags(conv__assert_shape=True)
     @pytest.mark.skipif(theano.config.cxx == "", reason="test needs cxx")
     def test_shape_check_conv3d_grad_wrt_weights(self):
         input = tensor.tensor5()

--- a/tests/tensor/nnet/test_neighbours.py
+++ b/tests/tensor/nnet/test_neighbours.py
@@ -4,7 +4,7 @@ import pytest
 import theano
 import theano.tensor as tt
 from tests import unittest_tools
-from theano import change_flags, function, shared
+from theano import config, function, shared
 from theano.tensor.nnet.neighbours import Images2Neibs, images2neibs, neibs2images
 
 
@@ -161,7 +161,7 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
                 # print g()
                 # assert numpy.allclose(images.get_value(borrow=True), g())
 
-    @change_flags(compute_test_value="off")
+    @config.change_flags(compute_test_value="off")
     def test_neibs_bad_shape(self):
         shape = (2, 3, 10, 10)
         for dtype in self.dtypes:
@@ -351,7 +351,7 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
                     f_full = theano.function([], x_using_full, mode=self.mode)
                     unittest_tools.assert_allclose(f_valid(), f_full())
 
-    @change_flags(compute_test_value="off")
+    @config.change_flags(compute_test_value="off")
     def test_neibs_bad_shape_wrap_centered(self):
         shape = (2, 3, 10, 10)
 

--- a/tests/tensor/nnet/test_nnet.py
+++ b/tests/tensor/nnet/test_nnet.py
@@ -874,7 +874,7 @@ class TestCrossEntropyCategorical1Hot(utt.InferShapeTester):
             assert crossentropy_softmax_argmax_1hot_with_bias in ops
             assert not [1 for o in ops if isinstance(o, tt.AdvancedSubtensor)]
 
-            with theano.change_flags([("warn__sum_div_dimshuffle_bug", False)]):
+            with theano.change_flags(warn__sum_div_dimshuffle_bug=False):
                 fgraph = gof.FunctionGraph([x, b, y], [tt.grad(expr, x)])
                 optdb.query(OPT_FAST_RUN).optimize(fgraph)
 
@@ -911,7 +911,7 @@ class TestCrossEntropyCategorical1Hot(utt.InferShapeTester):
             assert crossentropy_softmax_argmax_1hot_with_bias in ops
             assert not [1 for o in ops if isinstance(o, tt.AdvancedSubtensor)]
 
-            with theano.change_flags([("warn__sum_div_dimshuffle_bug", False)]):
+            with theano.change_flags(warn__sum_div_dimshuffle_bug=False):
                 fgraph = gof.FunctionGraph([x, b, y], [tt.grad(expr, x)])
                 optdb.query(OPT_FAST_RUN).optimize(fgraph)
 
@@ -949,7 +949,7 @@ class TestCrossEntropyCategorical1Hot(utt.InferShapeTester):
             assert crossentropy_softmax_argmax_1hot_with_bias in ops
             assert not [1 for o in ops if isinstance(o, tt.AdvancedSubtensor)]
 
-            with theano.change_flags([("warn__sum_div_dimshuffle_bug", False)]):
+            with theano.change_flags(warn__sum_div_dimshuffle_bug=False):
                 fgraph = gof.FunctionGraph([x, b, y], [tt.grad(expr, x)])
                 optdb.query(OPT_FAST_RUN).optimize(fgraph)
 

--- a/tests/tensor/nnet/test_nnet.py
+++ b/tests/tensor/nnet/test_nnet.py
@@ -135,7 +135,7 @@ class TestSoftmaxWithBias(utt.InferShapeTester):
         # broadcasted inputs pattern
         initial_W = np.asarray(
             [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]],
-            dtype=theano.config.floatX,
+            dtype=config.floatX,
         )
         W = theano.shared(value=initial_W, name="W")
         vbias = theano.shared(value=0.1, name="vbias")  # 0.01
@@ -210,7 +210,7 @@ class TestLogSoftmax(utt.InferShapeTester):
         utt.verify_grad(f, [np.random.rand(4)])
 
     def test_allclose(self):
-        m = theano.config.mode
+        m = config.mode
         m = theano.compile.get_mode(m)
         m.check_isfinite = False
         x, y = tt.matrices("xy")
@@ -225,9 +225,9 @@ class TestLogSoftmax(utt.InferShapeTester):
         grad = tt.grad(cm2.mean(), x)
 
         # create some inputs into a softmax that are large and labels
-        a = np.exp(10 * np.random.rand(5, 10).astype(theano.config.floatX))
+        a = np.exp(10 * np.random.rand(5, 10).astype(config.floatX))
         # create some one-hot coded labels
-        b = np.eye(5, 10).astype(theano.config.floatX)
+        b = np.eye(5, 10).astype(config.floatX)
 
         # show equivalence of softmax and exponentiated numerically stable
         # log-softmax
@@ -272,12 +272,12 @@ class TestLogSoftmax(utt.InferShapeTester):
         # grad and that the new operation does not explode for big inputs.
         # Note that only the grad is checked.
 
-        m = theano.config.mode
+        m = config.mode
         m = theano.compile.get_mode(m)
         m.check_isfinite = False
         # some inputs that are large to make the gradient explode in the non
         # optimized case
-        a = np.exp(10 * np.random.rand(5, 10).astype(theano.config.floatX))
+        a = np.exp(10 * np.random.rand(5, 10).astype(config.floatX))
 
         def myfunc(x):
             sm = softmax(x)
@@ -874,7 +874,7 @@ class TestCrossEntropyCategorical1Hot(utt.InferShapeTester):
             assert crossentropy_softmax_argmax_1hot_with_bias in ops
             assert not [1 for o in ops if isinstance(o, tt.AdvancedSubtensor)]
 
-            with theano.change_flags(warn__sum_div_dimshuffle_bug=False):
+            with config.change_flags(warn__sum_div_dimshuffle_bug=False):
                 fgraph = gof.FunctionGraph([x, b, y], [tt.grad(expr, x)])
                 optdb.query(OPT_FAST_RUN).optimize(fgraph)
 
@@ -911,7 +911,7 @@ class TestCrossEntropyCategorical1Hot(utt.InferShapeTester):
             assert crossentropy_softmax_argmax_1hot_with_bias in ops
             assert not [1 for o in ops if isinstance(o, tt.AdvancedSubtensor)]
 
-            with theano.change_flags(warn__sum_div_dimshuffle_bug=False):
+            with config.change_flags(warn__sum_div_dimshuffle_bug=False):
                 fgraph = gof.FunctionGraph([x, b, y], [tt.grad(expr, x)])
                 optdb.query(OPT_FAST_RUN).optimize(fgraph)
 
@@ -949,7 +949,7 @@ class TestCrossEntropyCategorical1Hot(utt.InferShapeTester):
             assert crossentropy_softmax_argmax_1hot_with_bias in ops
             assert not [1 for o in ops if isinstance(o, tt.AdvancedSubtensor)]
 
-            with theano.change_flags(warn__sum_div_dimshuffle_bug=False):
+            with config.change_flags(warn__sum_div_dimshuffle_bug=False):
                 fgraph = gof.FunctionGraph([x, b, y], [tt.grad(expr, x)])
                 optdb.query(OPT_FAST_RUN).optimize(fgraph)
 
@@ -1056,12 +1056,9 @@ def test_argmax_pushdown():
         fgraph = gof.FunctionGraph([x], [out])
 
         assert hasattr(fgraph.outputs[0].tag, "trace")
-        backup = config.warn__argmax_pushdown_bug
-        config.warn__argmax_pushdown_bug = False
-        try:
+
+        with config.change_flags(warn__argmax_pushdown_bug=False):
             optdb.query(OPT_FAST_RUN).optimize(fgraph)
-        finally:
-            config.warn__argmax_pushdown_bug = backup
 
         # print 'AFTER'
         # for node in fgraph.toposort():
@@ -1082,9 +1079,6 @@ def test_argmax_pushdown_bias():
 
     optdb.query(OPT_FAST_RUN).optimize(fgraph)
 
-    # print 'AFTER'
-    # for node in fgraph.toposort():
-    #    print node.op
     types_to_check = (tt.DimShuffle, tt.Elemwise, tt.Argmax)
     assert len(fgraph.toposort()) == 3
 
@@ -1097,16 +1091,9 @@ def test_argmax_pushdown_bias():
     out = tt.max_and_argmax(softmax_with_bias(x, b), axis=-1)[0]
     fgraph = gof.FunctionGraph([x, b], [out])
 
-    backup = config.warn__argmax_pushdown_bug
-    config.warn__argmax_pushdown_bug = False
-    try:
+    with config.change_flags(warn__argmax_pushdown_bug=False):
         optdb.query(OPT_FAST_RUN).optimize(fgraph)
-    finally:
-        config.warn__argmax_pushdown_bug = backup
 
-    # print 'AFTER'
-    # for node in fgraph.toposort():
-    #    print node.op
     assert len(fgraph.toposort()) == 2
     assert isinstance(fgraph.toposort()[0].op, SoftmaxWithBias)
     assert isinstance(fgraph.toposort()[1].op, tt.CAReduce)
@@ -1138,7 +1125,7 @@ def test_asymptotic_32():
         for i in range(100):
             cval, gxval = f(xval, np.arange(5), x2val)
             xval -= 100.3 * gxval
-            # print cval, gxval
+
         assert cval == 0  # no problem going to zero error
 
         # what about when x gets really big?
@@ -1149,7 +1136,6 @@ def test_asymptotic_32():
 
             cval, gxval = f(xval, np.arange(5), x2val)
             xval += 100000.3 * gxval
-            # print cval, gxval
 
         assert cval > 61750000
         assert gxval[0, 0] == -1.0
@@ -1182,11 +1168,10 @@ class TestSoftmaxOpt:
         assert check_stack_trace(f, ops_to_check=softmax_op)
 
         f_ops = [n.op for n in f.maker.fgraph.toposort()]
-        # print '--- f ='
-        # printing.debugprint(f)
-        # print '==='
+
         assert len(f_ops) == 1
         assert softmax_op in f_ops
+
         f(self.rng.rand(3, 4).astype(config.floatX))
 
     def test_basic_keepdims(self):
@@ -1199,11 +1184,10 @@ class TestSoftmaxOpt:
         assert check_stack_trace(f, ops_to_check=softmax_op)
 
         f_ops = [n.op for n in f.maker.fgraph.toposort()]
-        # print '--- f ='
-        # printing.debugprint(f)
-        # print '==='
+
         assert len(f_ops) == 1
         assert softmax_op in f_ops
+
         f(self.rng.rand(3, 4).astype(config.floatX))
 
     @pytest.mark.skip(reason="Optimization not enabled for the moment")
@@ -1213,20 +1197,16 @@ class TestSoftmaxOpt:
 
         # test that function contains softmax and softmaxgrad
         w = tt.matrix()
-        backup = config.warn__sum_div_dimshuffle_bug
-        config.warn__sum_div_dimshuffle_bug = False
-        try:
+
+        with config.change_flags(warn__sum_div_dimshuffle_bug=False):
             g = theano.function([c, w], tt.grad((p_y * w).sum(), c))
-        finally:
-            config.warn__sum_div_dimshuffle_bug = backup
+
         g_ops = [n.op for n in g.maker.fgraph.toposort()]
-        # print '--- g ='
-        # printing.debugprint(g)
-        # print '==='
 
         assert len(g_ops) == 2
         assert softmax_op in g_ops
         assert softmax_grad in g_ops
+
         g(self.rng.rand(3, 4), self.rng.uniform(0.5, 1, (3, 4)))
 
     @pytest.mark.skip(reason="Optimization not enabled for the moment")
@@ -1237,16 +1217,10 @@ class TestSoftmaxOpt:
 
         # test that function contains softmax and no div.
         theano.function([c], p_y)
-        # printing.debugprint(f)
 
         # test that function contains softmax and no div.
-        backup = config.warn__sum_div_dimshuffle_bug
-        config.warn__sum_div_dimshuffle_bug = False
-        try:
+        with config.change_flags(warn__sum_div_dimshuffle_bug=False):
             theano.function([c], tt.grad(p_y.sum(), c))
-        finally:
-            config.warn__sum_div_dimshuffle_bug = backup
-        # printing.debugprint(g)
 
     @pytest.mark.skip(reason="Optimization not enabled for the moment")
     def test_1d_basic(self):
@@ -1256,19 +1230,10 @@ class TestSoftmaxOpt:
 
         # test that function contains softmax and no div.
         theano.function([c], p_y)
-        # printing.debugprint(f)
 
         # test that function contains softmax and no div.
-        backup = config.warn__sum_div_dimshuffle_bug
-        config.warn__sum_div_dimshuffle_bug = False
-        try:
+        with config.change_flags(warn__sum_div_dimshuffle_bug=False):
             theano.function([c], tt.grad(p_y.sum(), c))
-        finally:
-            config.warn__sum_div_dimshuffle_bug = backup
-        # printing.debugprint(g)
-
-    # REPEAT 3 CASES in presence of log(softmax) with the advanced indexing
-    # etc.
 
 
 def test_softmax_graph():
@@ -1349,47 +1314,36 @@ def test_h_softmax():
     # Tests the output dimensions of the h_softmax when a target is provided or
     # not.
 
-    #############
-    # Config
-    #############
-
     input_size = 4
     batch_size = 2
     h_softmax_level1_size = 5
     h_softmax_level2_size = 3
     output_size = h_softmax_level1_size * h_softmax_level2_size
 
-    #############
-    # Initialize shared variables
-    #############
-
-    floatX = theano.config.floatX
-    shared = theano.shared
-
     # First level of h_softmax
     W1 = np.asarray(
-        np.random.normal(size=(input_size, h_softmax_level1_size)), dtype=floatX
+        np.random.normal(size=(input_size, h_softmax_level1_size)), dtype=config.floatX
     )
-    W1 = shared(W1)
-    b1 = shared(np.asarray(np.zeros((h_softmax_level1_size,)), dtype=floatX))
+    W1 = theano.shared(W1)
+    b1 = theano.shared(
+        np.asarray(np.zeros((h_softmax_level1_size,)), dtype=config.floatX)
+    )
 
     # Second level of h_softmax
     W2 = np.asarray(
         np.random.normal(
             size=(h_softmax_level1_size, input_size, h_softmax_level2_size)
         ),
-        dtype=floatX,
+        dtype=config.floatX,
     )
-    W2 = shared(W2)
-    b2 = shared(
+    W2 = theano.shared(W2)
+    b2 = theano.shared(
         np.asarray(
-            np.zeros((h_softmax_level1_size, h_softmax_level2_size)), dtype=floatX
+            np.zeros((h_softmax_level1_size, h_softmax_level2_size)),
+            dtype=config.floatX,
         )
     )
 
-    #############
-    # Build graph
-    #############
     x = tt.matrix("x")
     y = tt.ivector("y")
 
@@ -1420,16 +1374,10 @@ def test_h_softmax():
         b2,
     )
 
-    #############
-    # Compile functions
-    #############
     fun_output_tg = theano.function([x, y], y_hat_tg)
     fun_output = theano.function([x], y_hat_all)
 
-    #############
-    # Test
-    #############
-    x_mat = np.random.normal(size=(batch_size, input_size)).astype(floatX)
+    x_mat = np.random.normal(size=(batch_size, input_size)).astype(config.floatX)
     y_mat = np.random.randint(0, output_size, batch_size).astype("int32")
     tg_output = fun_output_tg(x_mat, y_mat)
     all_outputs = fun_output(x_mat)

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -68,7 +68,7 @@ from tests.tensor.utils import (
     upcast_float16_ufunc,
     upcast_int8_nfunc,
 )
-from theano import change_flags, compile, config, function, gof, shared
+from theano import compile, config, function, gof, shared
 from theano.compile import DeepCopyOp
 from theano.compile.mode import get_default_mode
 from theano.gof.graph import Variable
@@ -1034,7 +1034,7 @@ class TestAsTensorVariable:
         # Make sure our exception handling during `Sequence` processing doesn't
         # mask exceptions caused by unrelated logic (e.g.  computing test
         # values)
-        with change_flags(compute_test_value="raise"), pytest.raises(ValueError):
+        with config.change_flags(compute_test_value="raise"), pytest.raises(ValueError):
             a = tt.lscalar("a")
             y = (a, a, 1)
             _ = as_tensor_variable(y)
@@ -1079,7 +1079,7 @@ class TestAsTensorVariable:
         ],
     )
     def test_empty_dtype(self, dtype):
-        with theano.change_flags(floatX=dtype):
+        with config.change_flags(floatX=dtype):
             assert as_tensor_variable(()).dtype == dtype
             assert as_tensor_variable([]).dtype == dtype
 
@@ -1211,7 +1211,7 @@ def test_eye():
         M = M_
         # Currently DebugMode does not support None as inputs even if this is
         # allowed.
-        if M is None and theano.config.mode in ["DebugMode", "DEBUG_MODE"]:
+        if M is None and config.mode in ["DebugMode", "DEBUG_MODE"]:
             M = N
         N_symb = tt.iscalar()
         M_symb = tt.iscalar()
@@ -1245,7 +1245,7 @@ class TestTriangle:
             M = M_
             # Currently DebugMode does not support None as inputs even if this is
             # allowed.
-            if M is None and theano.config.mode in ["DebugMode", "DEBUG_MODE"]:
+            if M is None and config.mode in ["DebugMode", "DEBUG_MODE"]:
                 M = N
             N_symb = tt.iscalar()
             M_symb = tt.iscalar()
@@ -1310,7 +1310,7 @@ class TestTriangle:
 
 
 class TestNonzero:
-    @change_flags(compute_test_value="raise")
+    @config.change_flags(compute_test_value="raise")
     def test_nonzero(self):
         def check(m):
             m_symb = tt.tensor(dtype=m.dtype, broadcastable=(False,) * m.ndim)
@@ -1339,7 +1339,7 @@ class TestNonzero:
         rand2d[:4] = 0
         check(rand2d)
 
-    @change_flags(compute_test_value="raise")
+    @config.change_flags(compute_test_value="raise")
     def test_flatnonzero(self):
         def check(m):
             m_symb = tt.tensor(dtype=m.dtype, broadcastable=(False,) * m.ndim)
@@ -1362,7 +1362,7 @@ class TestNonzero:
         rand2d[:4] = 0
         check(rand2d)
 
-    @change_flags(compute_test_value="raise")
+    @config.change_flags(compute_test_value="raise")
     def test_nonzero_values(self):
         def check(m):
             m_symb = tt.tensor(dtype=m.dtype, broadcastable=(False,) * m.ndim)
@@ -1395,7 +1395,7 @@ def test_identity():
         assert obj.dtype == f(obj).dtype
         topo = f.maker.fgraph.toposort()
         assert len(topo) == 1
-        if theano.config.mode != "FAST_COMPILE":
+        if config.mode != "FAST_COMPILE":
             assert isinstance(topo[0].op, DeepCopyOp)
 
     for dtype in ALL_DTYPES:
@@ -2398,7 +2398,7 @@ class TestJoinAndSplit:
         self.split_op_class = Split
         self.make_vector_op = opt.MakeVector()
         self.floatX = config.floatX
-        self.hide_error = theano.config.mode not in [
+        self.hide_error = config.mode not in [
             "DebugMode",
             "DEBUG_MODE",
             "FAST_COMPILE",
@@ -2985,7 +2985,7 @@ class TestJoinAndSplit:
 
         f = function([], b, mode=self.mode)
         topo = f.maker.fgraph.toposort()
-        if theano.config.mode != "FAST_COMPILE":
+        if config.mode != "FAST_COMPILE":
             assert not [
                 True for node in topo if isinstance(node.op, type(self.join_op))
             ]
@@ -3078,7 +3078,7 @@ class TestJoinAndSplit:
         out = f()
         assert (out == [6, 4]).all()
 
-        if theano.config.mode != "FAST_COMPILE":
+        if config.mode != "FAST_COMPILE":
             for node in f.maker.fgraph.toposort():
                 assert not isinstance(node.op, type(self.join_op))
 
@@ -3092,11 +3092,11 @@ class TestJoinAndSplit:
         out = f()
         assert (out == [3, 13]).all()
 
-        if theano.config.mode != "FAST_COMPILE":
+        if config.mode != "FAST_COMPILE":
             for node in topo:
                 assert not isinstance(node.op, type(self.join_op))
 
-        with change_flags(compute_test_value="off"):
+        with config.change_flags(compute_test_value="off"):
             # Test hide error
             x1.set_value(get_mat(3, 4))
             x2.set_value(get_mat(3, 4))
@@ -3123,7 +3123,7 @@ class TestJoinAndSplit:
         Tout = tt.concatenate([T_shared, T_shared])
         f = function([], Tout, mode=self.mode)
         out = f()
-        if theano.config.mode != "FAST_COMPILE":
+        if config.mode != "FAST_COMPILE":
             assert [
                 True
                 for node in f.maker.fgraph.toposort()
@@ -3155,7 +3155,7 @@ class TestJoinAndSplit:
         assert np.allclose(o1, m.get_value(borrow=True))
         assert np.allclose(o2, m.get_value(borrow=True)[4:])
 
-    @change_flags(compute_test_value="off")
+    @config.change_flags(compute_test_value="off")
     def test_split_neg(self):
         rng = np.random.RandomState(seed=utt.fetch_seed())
         m = self.shared(rng.rand(4, 6).astype(self.floatX))
@@ -3187,10 +3187,10 @@ def test_join_inplace():
 
     f = theano.function([theano.In(x, borrow=True), s], theano.Out(c, borrow=True))
 
-    data = np.array([3, 4, 5], dtype=theano.config.floatX)
+    data = np.array([3, 4, 5], dtype=config.floatX)
     print(f(data, 0))
 
-    if theano.config.mode not in ["DebugMode", "DEBUG_MODE"]:
+    if config.mode not in ["DebugMode", "DEBUG_MODE"]:
         assert f(data, 0) is data
     assert np.allclose(f(data, 0), [3, 4, 5])
 
@@ -3937,7 +3937,7 @@ class TestReshape(utt.InferShapeTester, utt.OptimizationTestMixin):
 
     def function(self, inputs, outputs, ignore_empty=False):
         f = function(inputs, outputs, mode=self.mode)
-        if self.mode is not None or theano.config.mode != "FAST_COMPILE":
+        if self.mode is not None or config.mode != "FAST_COMPILE":
             topo = f.maker.fgraph.toposort()
             topo_ = [node for node in topo if not isinstance(node.op, self.ignore_topo)]
             if ignore_empty:
@@ -4678,7 +4678,7 @@ class TestARange:
     def test_infer_shape(self):
         start, stop, step = iscalars("start", "stop", "step")
         out = arange(start, stop, step)
-        mode = theano.config.mode
+        mode = config.mode
         if mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         mode = compile.mode.get_mode(mode).excluding("fusion")
@@ -5284,18 +5284,14 @@ def test_default_state():
 
 
 def test_autocast():
-    backup_config = config.cast_policy
     # Call test functions for all possible values of `config.cast_policy`.
     for autocast_cfg in (
         "custom",
         # 'numpy', # Commented out until it is implemented properly.
         "numpy+floatX",
     ):
-        config.cast_policy = autocast_cfg
-        try:
+        with config.change_flags(cast_policy=autocast_cfg):
             eval("_test_autocast_" + autocast_cfg.replace("+", "_"))()
-        finally:
-            config.cast_policy = backup_config
 
 
 def _test_autocast_custom():
@@ -5344,14 +5340,14 @@ def _test_autocast_custom():
     # Test that the autocasting dtype is used correctly in expression-building
     with autocast_float_as("float32", "float64"):
         assert (dvector() + 1.1).dtype == "float64"
-        assert (fvector() + 1.1).dtype == theano.config.floatX
+        assert (fvector() + 1.1).dtype == config.floatX
         assert (fvector() + 1.0).dtype == "float32"
         assert (dvector() + np.float32(1.1)).dtype == "float64"
         assert (dvector() + np.float64(1.1)).dtype == "float64"
         assert (dvector() + np.float(1.1)).dtype == "float64"
         assert (fvector() + np.float32(1.1)).dtype == "float32"
         assert (fvector() + np.float64(1.1)).dtype == "float64"
-        assert (fvector() + np.float(1.1)).dtype == theano.config.floatX
+        assert (fvector() + np.float(1.1)).dtype == config.floatX
         assert (lvector() + np.int64(1)).dtype == "int64"
         assert (lvector() + np.int32(1)).dtype == "int64"
         assert (lvector() + np.int16(1)).dtype == "int64"
@@ -5386,7 +5382,6 @@ def _test_autocast_numpy():
 def _test_autocast_numpy_floatX():
     # Called from `test_autocast`.
     assert config.cast_policy == "numpy+floatX"
-    backup_floatX = config.floatX
 
     def ok(z, floatX):
         if isinstance(z, float) and floatX == "float32" and not hasattr(z, "dtype"):
@@ -5395,27 +5390,24 @@ def _test_autocast_numpy_floatX():
         else:
             assert tt.constant(z).dtype == np.asarray(z).dtype
 
-    try:
-        # Test with various values of `config.floatX`.
-        for floatX in ("float32", "float64"):
-            config.floatX = floatX
-            # Go through some typical scalar values.
-            # We only consider 'int' and 'long' Python values that can fit
-            # into int64, as that is the maximal integer type that Theano
-            # supports, and that is the maximal type in Python indexing.
-            for x in (
-                [2 ** i - 1 for i in range(64)]
-                + [0, 0, 1, 2 ** 63 - 1]
-                + [0.0, 1.0, 1.1, 1.5]
-            ):
+    # Test with various values of `config.floatX`.
+    for floatX in ("float32", "float64"):
+        # Go through some typical scalar values.
+        # We only consider 'int' and 'long' Python values that can fit
+        # into int64, as that is the maximal integer type that Theano
+        # supports, and that is the maximal type in Python indexing.
+        for x in (
+            [2 ** i - 1 for i in range(64)]
+            + [0, 0, 1, 2 ** 63 - 1]
+            + [0.0, 1.0, 1.1, 1.5]
+        ):
+            with config.change_flags(floatX=floatX):
                 ok(x, floatX)
                 ok(-x, floatX)
                 ok(x - 1, floatX)
                 ok(-x + 1, floatX)
                 ok(np.asarray(x), floatX)
                 ok(np.float64(x), floatX)
-    finally:
-        config.floatX = backup_floatX
 
 
 class TestArithmeticCast:
@@ -5428,7 +5420,6 @@ class TestArithmeticCast:
     """
 
     def test_arithmetic_cast(self):
-        backup_config = config.cast_policy
         dtypes = get_numeric_types(with_complex=True)
 
         # Here:
@@ -5453,151 +5444,143 @@ class TestArithmeticCast:
         def numpy_i_scalar(dtype):
             return numpy_scalar(dtype)
 
-        if config.int_division == "int":
+        with warnings.catch_warnings():
             # Avoid deprecation warning during tests.
-            warnings.filterwarnings(
-                "ignore", message="Division of two integer", category=DeprecationWarning
-            )
-        try:
+            warnings.simplefilter("ignore", category=DeprecationWarning)
             for cfg in ("numpy+floatX",):  # Used to test 'numpy' as well.
-                config.cast_policy = cfg
-                for op in (
-                    operator.add,
-                    operator.sub,
-                    operator.mul,
-                    operator.truediv,
-                    operator.floordiv,
-                ):
-                    for a_type in dtypes:
-                        for b_type in dtypes:
-                            # Note that we do not test division between
-                            # integers if it is forbidden.
-                            # Theano deals with integer division in its own
-                            # special way (depending on `config.int_division`).
-                            is_int_division = (
-                                op is operator.truediv
-                                and a_type in tt.discrete_dtypes
-                                and b_type in tt.discrete_dtypes
-                            )
-                            # We will test all meaningful combinations of
-                            # scalar and array operations.
-                            for combo in (
-                                ("scalar", "scalar"),
-                                ("array", "array"),
-                                ("scalar", "array"),
-                                ("array", "scalar"),
-                                ("i_scalar", "i_scalar"),
-                            ):
+                with config.change_flags(cast_policy=cfg):
+                    for op in (
+                        operator.add,
+                        operator.sub,
+                        operator.mul,
+                        operator.truediv,
+                        operator.floordiv,
+                    ):
+                        for a_type in dtypes:
+                            for b_type in dtypes:
+                                # Note that we do not test division between
+                                # integers if it is forbidden.
+                                # Theano deals with integer division in its own
+                                # special way (depending on `config.int_division`).
+                                is_int_division = (
+                                    op is operator.truediv
+                                    and a_type in tt.discrete_dtypes
+                                    and b_type in tt.discrete_dtypes
+                                )
+                                # We will test all meaningful combinations of
+                                # scalar and array operations.
+                                for combo in (
+                                    ("scalar", "scalar"),
+                                    ("array", "array"),
+                                    ("scalar", "array"),
+                                    ("array", "scalar"),
+                                    ("i_scalar", "i_scalar"),
+                                ):
 
-                                theano_args = list(
-                                    map(eval, [f"theano_{c}" for c in combo])
-                                )
-                                numpy_args = list(
-                                    map(eval, [f"numpy_{c}" for c in combo])
-                                )
-                                try:
-                                    theano_dtype = op(
-                                        theano_args[0](a_type), theano_args[1](b_type)
-                                    ).type.dtype
-                                    # Should have crashed if it is an integer
-                                    # division and `config.int_division` does
-                                    # not allow it.
-                                    assert not (
-                                        is_int_division
-                                        and config.int_division == "raise"
+                                    theano_args = list(
+                                        map(eval, [f"theano_{c}" for c in combo])
                                     )
-                                except theano.scalar.IntegerDivisionError:
-                                    assert (
-                                        is_int_division
-                                        and config.int_division == "raise"
+                                    numpy_args = list(
+                                        map(eval, [f"numpy_{c}" for c in combo])
                                     )
-                                    # This is the expected behavior.
-                                    continue
-                                # For numpy we have a problem:
-                                #   http://projects.scipy.org/numpy/ticket/1827
-                                # As a result we only consider the highest data
-                                # type that numpy may return.
-                                numpy_dtypes = [
-                                    op(
-                                        numpy_args[0](a_type), numpy_args[1](b_type)
-                                    ).dtype,
-                                    op(
-                                        numpy_args[1](b_type), numpy_args[0](a_type)
-                                    ).dtype,
-                                ]
-                                numpy_dtype = theano.scalar.upcast(
-                                    *list(map(str, numpy_dtypes))
-                                )
-                                if numpy_dtype == theano_dtype:
-                                    # Same data type found, all is good!
-                                    continue
-                                if (
-                                    cfg == "numpy+floatX"
-                                    and config.floatX == "float32"
-                                    and a_type != "float64"
-                                    and b_type != "float64"
-                                    and numpy_dtype == "float64"
-                                ):
-                                    # We should keep float32.
-                                    assert theano_dtype == "float32"
-                                    continue
-                                if "array" in combo and "scalar" in combo:
-                                    # For mixed scalar / array operations,
-                                    # Theano may differ from numpy as it does
-                                    # not try to prevent the scalar from
-                                    # upcasting the array.
-                                    array_type, scalar_type = (
-                                        (a_type, b_type)[list(combo).index(arg)]
-                                        for arg in ("array", "scalar")
-                                    )
-                                    up_type = theano.scalar.upcast(
-                                        array_type, scalar_type
-                                    )
-                                    if (
-                                        # The two data types are different.
-                                        scalar_type != array_type
-                                        and
-                                        # The array type is not enough to hold
-                                        # the scalar type as well.
-                                        array_type != up_type
-                                        and
-                                        # Theano upcasted the result array.
-                                        theano_dtype == up_type
-                                        and
-                                        # But Numpy kept its original type.
-                                        array_type == numpy_dtype
-                                    ):
-                                        # Then we accept this difference in
-                                        # behavior.
+                                    try:
+                                        theano_dtype = op(
+                                            theano_args[0](a_type),
+                                            theano_args[1](b_type),
+                                        ).type.dtype
+                                        # Should have crashed if it is an integer
+                                        # division and `config.int_division` does
+                                        # not allow it.
+                                        assert not (
+                                            is_int_division
+                                            and config.int_division == "raise"
+                                        )
+                                    except theano.scalar.IntegerDivisionError:
+                                        assert (
+                                            is_int_division
+                                            and config.int_division == "raise"
+                                        )
+                                        # This is the expected behavior.
                                         continue
-                                if is_int_division and config.int_division == "floatX":
-                                    assert theano_dtype == config.floatX
-                                    continue
-                                if (
-                                    cfg == "numpy+floatX"
-                                    and a_type == "complex128"
-                                    and (b_type == "float32" or b_type == "float16")
-                                    and combo == ("scalar", "array")
-                                    and theano_dtype == "complex128"
-                                    and numpy_dtype == "complex64"
-                                ):
-                                    # In numpy 1.6.x adding a complex128 with
-                                    # a float32 may result in a complex64. As
-                                    # of 1.9.2. this is still the case so it is
-                                    # probably by design
-                                    pytest.skip("Known issue with" "numpy see #761")
-                                # In any other situation: something wrong is
-                                # going on!
-                                raise AssertionError()
-        finally:
-            config.cast_policy = backup_config
-            if config.int_division == "int":
-                # Restore default deprecation warning behavior.
-                warnings.filterwarnings(
-                    "default",
-                    message="Division of two integer",
-                    category=DeprecationWarning,
-                )
+                                    # For numpy we have a problem:
+                                    #   http://projects.scipy.org/numpy/ticket/1827
+                                    # As a result we only consider the highest data
+                                    # type that numpy may return.
+                                    numpy_dtypes = [
+                                        op(
+                                            numpy_args[0](a_type), numpy_args[1](b_type)
+                                        ).dtype,
+                                        op(
+                                            numpy_args[1](b_type), numpy_args[0](a_type)
+                                        ).dtype,
+                                    ]
+                                    numpy_dtype = theano.scalar.upcast(
+                                        *list(map(str, numpy_dtypes))
+                                    )
+                                    if numpy_dtype == theano_dtype:
+                                        # Same data type found, all is good!
+                                        continue
+                                    if (
+                                        cfg == "numpy+floatX"
+                                        and config.floatX == "float32"
+                                        and a_type != "float64"
+                                        and b_type != "float64"
+                                        and numpy_dtype == "float64"
+                                    ):
+                                        # We should keep float32.
+                                        assert theano_dtype == "float32"
+                                        continue
+                                    if "array" in combo and "scalar" in combo:
+                                        # For mixed scalar / array operations,
+                                        # Theano may differ from numpy as it does
+                                        # not try to prevent the scalar from
+                                        # upcasting the array.
+                                        array_type, scalar_type = (
+                                            (a_type, b_type)[list(combo).index(arg)]
+                                            for arg in ("array", "scalar")
+                                        )
+                                        up_type = theano.scalar.upcast(
+                                            array_type, scalar_type
+                                        )
+                                        if (
+                                            # The two data types are different.
+                                            scalar_type != array_type
+                                            and
+                                            # The array type is not enough to hold
+                                            # the scalar type as well.
+                                            array_type != up_type
+                                            and
+                                            # Theano upcasted the result array.
+                                            theano_dtype == up_type
+                                            and
+                                            # But Numpy kept its original type.
+                                            array_type == numpy_dtype
+                                        ):
+                                            # Then we accept this difference in
+                                            # behavior.
+                                            continue
+                                    if (
+                                        is_int_division
+                                        and config.int_division == "floatX"
+                                    ):
+                                        assert theano_dtype == config.floatX
+                                        continue
+                                    if (
+                                        cfg == "numpy+floatX"
+                                        and a_type == "complex128"
+                                        and (b_type == "float32" or b_type == "float16")
+                                        and combo == ("scalar", "array")
+                                        and theano_dtype == "complex128"
+                                        and numpy_dtype == "complex64"
+                                    ):
+                                        # In numpy 1.6.x adding a complex128 with
+                                        # a float32 may result in a complex64. As
+                                        # of 1.9.2. this is still the case so it is
+                                        # probably by design
+                                        pytest.skip("Known issue with" "numpy see #761")
+                                    # In any other situation: something wrong is
+                                    # going on!
+                                    raise AssertionError()
 
 
 class TestLongTensor:
@@ -5709,7 +5692,7 @@ class TestBroadcast:
         f = theano.function([x], y.shape)
         assert (f(np.zeros((1, 5), dtype=config.floatX)) == [1, 5]).all()
         topo = f.maker.fgraph.toposort()
-        if theano.config.mode != "FAST_COMPILE":
+        if config.mode != "FAST_COMPILE":
             assert len(topo) == 2
             assert isinstance(topo[0].op, opt.Shape_i)
             assert isinstance(topo[1].op, opt.MakeVector)
@@ -5719,7 +5702,7 @@ class TestBroadcast:
         f = theano.function([x], y.shape)
         assert (f(np.zeros((2, 5), dtype=config.floatX)) == [2, 5]).all()
         topo = f.maker.fgraph.toposort()
-        if theano.config.mode != "FAST_COMPILE":
+        if config.mode != "FAST_COMPILE":
             assert len(topo) == 3
             assert isinstance(topo[0].op, opt.Shape_i)
             assert isinstance(topo[1].op, opt.Shape_i)
@@ -5730,7 +5713,7 @@ class TestBroadcast:
         f = theano.function([x], y.shape)
         assert (f(np.zeros((1, 5), dtype=config.floatX)) == [1, 5]).all()
         topo = f.maker.fgraph.toposort()
-        if theano.config.mode != "FAST_COMPILE":
+        if config.mode != "FAST_COMPILE":
             assert len(topo) == 2
             assert isinstance(topo[0].op, opt.Shape_i)
             assert isinstance(topo[1].op, opt.MakeVector)
@@ -5924,7 +5907,7 @@ class TestGetScalarConstantValue:
         a = opt.Assert()(c, c > 1)
         assert get_scalar_constant_value(a) == 2
 
-        with change_flags(compute_test_value="off"):
+        with config.change_flags(compute_test_value="off"):
             # condition is always False
             a = opt.Assert()(c, c > 2)
             with pytest.raises(tt.NotScalarConstantError):
@@ -7032,10 +7015,10 @@ class TestSwapaxes:
 
     def test_numpy_compare(self):
         rng = np.random.RandomState(utt.fetch_seed())
-        A = tt.matrix("A", dtype=theano.config.floatX)
+        A = tt.matrix("A", dtype=config.floatX)
         Q = swapaxes(A, 0, 1)
         fn = function([A], [Q])
-        a = rng.rand(4, 4).astype(theano.config.floatX)
+        a = rng.rand(4, 4).astype(config.floatX)
 
         n_s = np.swapaxes(a, 0, 1)
         t_s = fn(a)
@@ -7045,10 +7028,10 @@ class TestSwapaxes:
 class TestPower:
     def test_numpy_compare(self):
         rng = np.random.RandomState(utt.fetch_seed())
-        A = tt.matrix("A", dtype=theano.config.floatX)
+        A = tt.matrix("A", dtype=config.floatX)
         Q = power(A, 3)
         fn = function([A], [Q])
-        a = rng.rand(4, 4).astype(theano.config.floatX)
+        a = rng.rand(4, 4).astype(config.floatX)
 
         n_p = np.power(a, 3)
         t_p = fn(a)
@@ -7237,5 +7220,5 @@ def test_allocempty():
 def test_symbolic_slice():
     x = tt.tensor4("x")
     a, b = x.shape[:2]
-    output = a.eval({x: np.zeros((5, 4, 3, 2), dtype=theano.config.floatX)})
+    output = a.eval({x: np.zeros((5, 4, 3, 2), dtype=config.floatX)})
     assert output == np.array(5)

--- a/tests/tensor/test_blas.py
+++ b/tests/tensor/test_blas.py
@@ -128,8 +128,8 @@ class TestGemm:
             cmp_linker(copy(z), a, x, y, b, "c|py")
             cmp_linker(copy(z), a, x, y, b, "py")
 
-            if not dtype.startswith("complex") and theano.config.cxx:
-                # If theano.config.blas__ldflags is empty, Theano will use
+            if not dtype.startswith("complex") and config.cxx:
+                # If config.blas__ldflags is empty, Theano will use
                 # a NumPy C implementation of [sd]gemm_.
                 cmp_linker(copy(z), a, x, y, b, "c")
 
@@ -477,7 +477,7 @@ class TestGemmNoFlags:
         C = self.get_value(C, transpose_C, slice_C)
         return alpha * np.dot(A, B) + beta * C
 
-    @theano.change_flags({"blas__ldflags": ""})
+    @config.change_flags({"blas__ldflags": ""})
     def run_gemm(
         self,
         dtype,
@@ -819,13 +819,9 @@ def test_upcasting_scalar_nogemm():
     t = tt.fmatrix("t")
     alpha = tt.cscalar("a")
 
-    on_opt_error = config.on_opt_error
-    try:
-        config.on_opt_error = "raise"
+    with config.change_flags(on_opt_error="raise"):
         rval = tt.dot(w, v) * alpha + t
         f = theano.function([w, v, t, alpha], rval)
-    finally:
-        config.on_opt_error = on_opt_error
 
     t = f.maker.fgraph.toposort()
     assert np.sum([isinstance(n.op, Gemm) for n in t]) == 0

--- a/tests/tensor/test_blas_c.py
+++ b/tests/tensor/test_blas_c.py
@@ -387,7 +387,7 @@ class TestCGemvNoFlags:
             ref_val += beta * y
         return ref_val
 
-    @theano.change_flags({"blas__ldflags": ""})
+    @theano.config.change_flags(blas__ldflags="")
     def run_cgemv(self, dtype, ALPHA, BETA, transpose_A, slice_tensors):
         f = self.get_function(
             dtype, transpose_A=transpose_A, slice_tensors=slice_tensors

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -3,7 +3,7 @@ import pytest
 
 import theano
 from tests import unittest_tools as utt
-from theano import change_flags, config, function
+from theano import config, function
 from theano import tensor as tt
 from theano.tensor.extra_ops import (
     Bartlett,
@@ -320,8 +320,8 @@ class TestSqueeze(utt.InferShapeTester):
 
     def test_op(self):
         for shape, broadcast in zip(self.shape_list, self.broadcast_list):
-            data = np.random.random(size=shape).astype(theano.config.floatX)
-            variable = tt.TensorType(theano.config.floatX, broadcast)()
+            data = np.random.random(size=shape).astype(config.floatX)
+            variable = tt.TensorType(config.floatX, broadcast)()
 
             f = theano.function([variable], self.op(variable))
 
@@ -333,8 +333,8 @@ class TestSqueeze(utt.InferShapeTester):
 
     def test_infer_shape(self):
         for shape, broadcast in zip(self.shape_list, self.broadcast_list):
-            data = np.random.random(size=shape).astype(theano.config.floatX)
-            variable = tt.TensorType(theano.config.floatX, broadcast)()
+            data = np.random.random(size=shape).astype(config.floatX)
+            variable = tt.TensorType(config.floatX, broadcast)()
 
             self._compile_and_check(
                 [variable], [self.op(variable)], [data], tt.DimShuffle, warn=False
@@ -342,15 +342,15 @@ class TestSqueeze(utt.InferShapeTester):
 
     def test_grad(self):
         for shape, broadcast in zip(self.shape_list, self.broadcast_list):
-            data = np.random.random(size=shape).astype(theano.config.floatX)
+            data = np.random.random(size=shape).astype(config.floatX)
 
             utt.verify_grad(self.op, [data])
 
     def test_var_interface(self):
         # same as test_op, but use a_theano_var.squeeze.
         for shape, broadcast in zip(self.shape_list, self.broadcast_list):
-            data = np.random.random(size=shape).astype(theano.config.floatX)
-            variable = tt.TensorType(theano.config.floatX, broadcast)()
+            data = np.random.random(size=shape).astype(config.floatX)
+            variable = tt.TensorType(config.floatX, broadcast)()
 
             f = theano.function([variable], variable.squeeze())
 
@@ -361,17 +361,17 @@ class TestSqueeze(utt.InferShapeTester):
             assert np.allclose(tested, expected)
 
     def test_axis(self):
-        variable = tt.TensorType(theano.config.floatX, [False, True, False])()
+        variable = tt.TensorType(config.floatX, [False, True, False])()
         res = squeeze(variable, axis=1)
 
         assert res.broadcastable == (False, False)
 
-        variable = tt.TensorType(theano.config.floatX, [False, True, False])()
+        variable = tt.TensorType(config.floatX, [False, True, False])()
         res = squeeze(variable, axis=(1,))
 
         assert res.broadcastable == (False, False)
 
-        variable = tt.TensorType(theano.config.floatX, [False, True, False, True])()
+        variable = tt.TensorType(config.floatX, [False, True, False, True])()
         res = squeeze(variable, axis=(1, 3))
 
         assert res.broadcastable == (False, False)
@@ -396,7 +396,7 @@ class TestCompress(utt.InferShapeTester):
     def test_op(self):
         for axis, cond, shape in zip(self.axis_list, self.cond_list, self.shape_list):
             cond_var = theano.tensor.ivector()
-            data = np.random.random(size=shape).astype(theano.config.floatX)
+            data = np.random.random(size=shape).astype(config.floatX)
             data_var = theano.tensor.matrix()
 
             f = theano.function(
@@ -713,7 +713,7 @@ def test_to_one_hot():
     o = to_one_hot(v, 10)
     f = theano.function([v], o)
     out = f([1, 2, 3, 5, 6])
-    assert out.dtype == theano.config.floatX
+    assert out.dtype == config.floatX
     assert np.allclose(
         out,
         [
@@ -1318,7 +1318,7 @@ class TestBroadcastTo(utt.InferShapeTester):
         self.op_class = BroadcastTo
         self.op = broadcast_to
 
-    @change_flags(compute_test_value="raise")
+    @config.change_flags(compute_test_value="raise")
     def test_perform(self):
         a = tt.scalar()
         a.tag.test_value = 5

--- a/tests/tensor/test_mpi.py
+++ b/tests/tensor/test_mpi.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 
 import theano
-from theano import change_flags
+from theano import config
 from theano.gof.sched import sort_schedule_fn
 from theano.tensor.io import (
     MPISend,
@@ -22,7 +22,7 @@ mpi_linker = theano.OpWiseCLinker(schedule=mpi_scheduler)
 mpi_mode = theano.Mode(linker=mpi_linker)
 
 
-@change_flags(compute_test_value="off")
+@config.change_flags(compute_test_value="off")
 def test_recv():
     x = recv((10, 10), "float64", 0, 11)
     assert x.dtype == "float64"
@@ -41,7 +41,7 @@ def test_send():
     assert sendnode.op.tag == 11
 
 
-@change_flags(compute_test_value="off")
+@config.change_flags(compute_test_value="off")
 def test_can_make_function():
     x = recv((5, 5), "float32", 0, 11)
     y = x + 1
@@ -83,7 +83,7 @@ def test_mpi_send_wait_cmp():
     assert mpi_send_wait_cmp(waitnode, addnode) > 0  # wait happens last
 
 
-@change_flags(compute_test_value="off")
+@config.change_flags(compute_test_value="off")
 def test_mpi_tag_ordering():
     x = recv((2, 2), "float32", 1, 12)
     y = recv((2, 2), "float32", 1, 11)

--- a/tests/tensor/test_nlinalg.py
+++ b/tests/tensor/test_nlinalg.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_array_almost_equal
 import theano
 from tests import unittest_tools as utt
 from theano import config, function, tensor
-from theano.configparser import change_flags
 from theano.tensor.basic import _allclose
 from theano.tensor.nlinalg import (
     SVD,
@@ -39,7 +38,7 @@ def test_pseudoinverse_correctness():
     rng = np.random.RandomState(utt.fetch_seed())
     d1 = rng.randint(4) + 2
     d2 = rng.randint(4) + 2
-    r = rng.randn(d1, d2).astype(theano.config.floatX)
+    r = rng.randn(d1, d2).astype(config.floatX)
 
     x = tensor.matrix()
     xi = pinv(x)
@@ -57,7 +56,7 @@ def test_pseudoinverse_grad():
     rng = np.random.RandomState(utt.fetch_seed())
     d1 = rng.randint(4) + 2
     d2 = rng.randint(4) + 2
-    r = rng.randn(d1, d2).astype(theano.config.floatX)
+    r = rng.randn(d1, d2).astype(config.floatX)
 
     utt.verify_grad(pinv, [r])
 
@@ -71,7 +70,7 @@ class TestMatrixInverse(utt.InferShapeTester):
 
     def test_inverse_correctness(self):
 
-        r = self.rng.randn(4, 4).astype(theano.config.floatX)
+        r = self.rng.randn(4, 4).astype(config.floatX)
 
         x = tensor.matrix()
         xi = self.op(x)
@@ -88,7 +87,7 @@ class TestMatrixInverse(utt.InferShapeTester):
 
     def test_infer_shape(self):
 
-        r = self.rng.randn(4, 4).astype(theano.config.floatX)
+        r = self.rng.randn(4, 4).astype(config.floatX)
 
         x = tensor.matrix()
         xi = self.op(x)
@@ -102,7 +101,7 @@ def test_matrix_dot():
     rs = []
     xs = []
     for k in range(n):
-        rs += [rng.randn(4, 4).astype(theano.config.floatX)]
+        rs += [rng.randn(4, 4).astype(config.floatX)]
         xs += [tensor.matrix()]
     sol = matrix_dot(*xs)
 
@@ -117,8 +116,8 @@ def test_matrix_dot():
 def test_qr_modes():
     rng = np.random.RandomState(utt.fetch_seed())
 
-    A = tensor.matrix("A", dtype=theano.config.floatX)
-    a = rng.rand(4, 4).astype(theano.config.floatX)
+    A = tensor.matrix("A", dtype=config.floatX)
+    a = rng.rand(4, 4).astype(config.floatX)
 
     f = function([A], qr(A))
     t_qr = f(a)
@@ -189,15 +188,15 @@ class TestSvd(utt.InferShapeTester):
 def test_tensorsolve():
     rng = np.random.RandomState(utt.fetch_seed())
 
-    A = tensor.tensor4("A", dtype=theano.config.floatX)
-    B = tensor.matrix("B", dtype=theano.config.floatX)
+    A = tensor.tensor4("A", dtype=config.floatX)
+    B = tensor.matrix("B", dtype=config.floatX)
     X = tensorsolve(A, B)
     fn = function([A, B], [X])
 
     # slightly modified example from np.linalg.tensorsolve docstring
-    a = np.eye(2 * 3 * 4).astype(theano.config.floatX)
+    a = np.eye(2 * 3 * 4).astype(config.floatX)
     a.shape = (2 * 3, 4, 2, 3 * 4)
-    b = rng.rand(2 * 3, 4).astype(theano.config.floatX)
+    b = rng.rand(2 * 3, 4).astype(config.floatX)
 
     n_x = np.linalg.tensorsolve(a, b)
     t_x = fn(a, b)
@@ -233,7 +232,7 @@ def test_tensorsolve():
 
 
 def test_inverse_singular():
-    singular = np.array([[1, 0, 0]] + [[0, 1, 0]] * 2, dtype=theano.config.floatX)
+    singular = np.array([[1, 0, 0]] + [[0, 1, 0]] * 2, dtype=config.floatX)
     a = tensor.matrix()
     f = function([a], matrix_inverse(a))
     with pytest.raises(np.linalg.LinAlgError):
@@ -527,20 +526,20 @@ class TestLstsq:
 
 
 class TestMatrixPower:
-    @change_flags(compute_test_value="raise")
+    @config.change_flags(compute_test_value="raise")
     @pytest.mark.parametrize("n", [-1, 0, 1, 2, 3, 4, 5, 11])
     def test_numpy_compare(self, n):
         a = np.array([[0.1231101, 0.72381381], [0.28748201, 0.43036511]]).astype(
-            theano.config.floatX
+            config.floatX
         )
-        A = tensor.matrix("A", dtype=theano.config.floatX)
+        A = tensor.matrix("A", dtype=config.floatX)
         A.tag.test_value = a
         Q = matrix_power(A, n)
         n_p = np.linalg.matrix_power(a, n)
         assert np.allclose(n_p, Q.get_test_value())
 
     def test_non_square_matrix(self):
-        A = tensor.matrix("A", dtype=theano.config.floatX)
+        A = tensor.matrix("A", dtype=config.floatX)
         Q = matrix_power(A, 3)
         f = function([A], [Q])
         a = np.array(
@@ -549,7 +548,7 @@ class TestMatrixPower:
                 [0.74387558, 0.31780172],
                 [0.54381007, 0.28153101],
             ]
-        ).astype(theano.config.floatX)
+        ).astype(config.floatX)
         with pytest.raises(ValueError):
             f(a)
 
@@ -574,11 +573,11 @@ class TestNormTests:
     def test_numpy_compare(self):
         rng = np.random.RandomState(utt.fetch_seed())
 
-        M = tensor.matrix("A", dtype=theano.config.floatX)
-        V = tensor.vector("V", dtype=theano.config.floatX)
+        M = tensor.matrix("A", dtype=config.floatX)
+        V = tensor.vector("V", dtype=config.floatX)
 
-        a = rng.rand(4, 4).astype(theano.config.floatX)
-        b = rng.rand(4).astype(theano.config.floatX)
+        a = rng.rand(4, 4).astype(config.floatX)
+        b = rng.rand(4).astype(config.floatX)
 
         A = (
             [None, "fro", "inf", "-inf", 1, -1, None, "inf", "-inf", 0, 1, -1, 2, -2],
@@ -597,12 +596,12 @@ class TestNormTests:
 class TestTensorInv(utt.InferShapeTester):
     def setup_method(self):
         super().setup_method()
-        self.A = tensor.tensor4("A", dtype=theano.config.floatX)
-        self.B = tensor.tensor3("B", dtype=theano.config.floatX)
-        self.a = np.random.rand(4, 6, 8, 3).astype(theano.config.floatX)
-        self.b = np.random.rand(2, 15, 30).astype(theano.config.floatX)
+        self.A = tensor.tensor4("A", dtype=config.floatX)
+        self.B = tensor.tensor3("B", dtype=config.floatX)
+        self.a = np.random.rand(4, 6, 8, 3).astype(config.floatX)
+        self.b = np.random.rand(2, 15, 30).astype(config.floatX)
         self.b1 = np.random.rand(30, 2, 15).astype(
-            theano.config.floatX
+            config.floatX
         )  # for ind=1 since we need prod(b1.shape[:ind]) == prod(b1.shape[ind:])
 
     def test_infer_shape(self):

--- a/tests/tensor/test_opt.py
+++ b/tests/tensor/test_opt.py
@@ -11,7 +11,7 @@ import theano.scalar as scal
 import theano.tensor as tt
 import theano.tensor.opt as opt
 from tests import unittest_tools as utt
-from theano import change_flags, compile, config, gof, pprint, shared
+from theano import compile, config, gof, pprint, shared
 from theano.compile import DeepCopyOp, deep_copy_op, get_mode
 from theano.compile.function import function
 from theano.gof import FunctionGraph
@@ -72,7 +72,7 @@ from theano.tensor.opt import (
 from theano.tensor.type import values_eq_approx_remove_nan
 
 
-mode_opt = theano.config.mode
+mode_opt = config.mode
 if mode_opt == "FAST_COMPILE":
     mode_opt = "FAST_RUN"
 mode_opt = theano.compile.mode.get_mode(mode_opt)
@@ -996,7 +996,7 @@ class TestCanonize:
         x = tt.dscalar()
         # a = T.abs_(x)
 
-        if theano.config.mode == "FAST_COMPILE":
+        if config.mode == "FAST_COMPILE":
             mode = theano.compile.mode.get_mode("FAST_RUN").excluding(
                 "local_elemwise_fusion"
             )
@@ -1110,7 +1110,7 @@ def test_local_merge_abs():
     x_val = np.random.rand(5, 5).astype(config.floatX)
     y_val = np.random.rand(5, 5).astype(config.floatX)
     z_val = np.random.rand(5, 5).astype(config.floatX)
-    mode = theano.config.mode
+    mode = config.mode
     if mode == "FAST_COMPILE":
         mode = "FAST_RUN"
     mode = theano.compile.mode.get_mode(mode).excluding("local_elemwise_fusion")
@@ -1931,7 +1931,7 @@ class TestFusion:
         for idx in range(1, 35):
             out = tt.sin(inpts[idx] + out)
 
-        with theano.change_flags(cxx=""):
+        with config.change_flags(cxx=""):
             f = function(inpts, out, mode=self.mode)
 
         # Make sure they all weren't fused
@@ -1942,7 +1942,7 @@ class TestFusion:
         ]
         assert not any(len(node.inputs) > 31 for node in composite_nodes)
 
-    @pytest.mark.skipif(not theano.config.cxx, reason="No cxx compiler")
+    @pytest.mark.skipif(not config.cxx, reason="No cxx compiler")
     def test_big_fusion(self):
         # In the past, pickle of Composite generated in that case
         # crashed with max recursion limit. So we were not able to
@@ -1957,7 +1957,7 @@ class TestFusion:
         cst_m2 = tt.constant(-2)
         ones = tt.constant(np.ones(10))
         n = 85
-        if theano.config.mode in ["DebugMode", "DEBUG_MODE"]:
+        if config.mode in ["DebugMode", "DEBUG_MODE"]:
             n = 10
 
         for i in range(n):
@@ -2083,7 +2083,7 @@ class TestFusion:
             ),
         )
 
-    @pytest.mark.skipif(not theano.config.cxx, reason="No cxx compiler")
+    @pytest.mark.skipif(not config.cxx, reason="No cxx compiler")
     def test_no_c_code(self):
         """Make sure we avoid fusions for `Op`s without C code implementations."""
 
@@ -2198,7 +2198,7 @@ class TestCompositeCodegen:
 
 @utt.assertFailure_fast
 def test_log1p():
-    m = theano.config.mode
+    m = config.mode
     if m == "FAST_COMPILE":
         m = "FAST_RUN"
     m = compile.mode.get_mode(m)
@@ -2249,7 +2249,7 @@ def test_log1p():
     reason="log(add(exp)) is not stabilized when adding more than 2 elements, see #623"
 )
 def test_log_add():
-    m = theano.config.mode
+    m = config.mode
     if m == "FAST_COMPILE":
         m = "FAST_RUN"
     m = compile.mode.get_mode(m)
@@ -3327,7 +3327,7 @@ class TestLocalSubtensorMerge:
 
     def test_const5(self):
         # Bug reported by Razvan
-        data = np.asarray(np.arange(8), dtype=theano.config.floatX)
+        data = np.asarray(np.arange(8), dtype=config.floatX)
         x = tt.vector("x")
         y = x[7:1:-1]
         t = theano.shared(np.int64(0))
@@ -3339,11 +3339,11 @@ class TestLocalSubtensorMerge:
 
     def test_const6(self):
         # Bug reported by Graham
-        data = self.rng.uniform(size=(8, 8, 8)).astype(theano.config.floatX)
+        data = self.rng.uniform(size=(8, 8, 8)).astype(config.floatX)
         x = tt.tensor3("x")
 
         nops = 1
-        if theano.config.mode == "FAST_COMPILE":
+        if config.mode == "FAST_COMPILE":
             nops = 2
 
         # test 1)
@@ -3763,7 +3763,7 @@ class TestAllocZero:
 
         assert len(inc_nodes) == 1
         node_is_set_instead_of_inc = inc_nodes[0].op.set_instead_of_inc
-        mode = theano.config.mode
+        mode = config.mode
         assert (mode != "FAST_COMPILE" and node_is_set_instead_of_inc) or (
             mode == "FAST_COMPILE" and not node_is_set_instead_of_inc
         )
@@ -3866,10 +3866,10 @@ class TestAllocZero:
         v2 = tt.vector("v2")
         m1 = tt.matrix("m1")
         m2 = tt.matrix("m2")
-        vv2 = np.asarray([0, 1], dtype=theano.config.floatX)
-        vm2 = np.asarray([[1, 2], [4, 5]], dtype=theano.config.floatX)
-        vv3 = np.asarray([0, 1, 2], dtype=theano.config.floatX)
-        vm3 = np.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=theano.config.floatX)
+        vv2 = np.asarray([0, 1], dtype=config.floatX)
+        vm2 = np.asarray([[1, 2], [4, 5]], dtype=config.floatX)
+        vv3 = np.asarray([0, 1, 2], dtype=config.floatX)
+        vm3 = np.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=config.floatX)
         for _e1 in [(v1, vv2, vv3), (m1, vm2, vm3)]:
             for _e2 in [(v2, vv2, vv3), (m2, vm2, vm3)]:
                 for p in [0, 1]:
@@ -3899,7 +3899,7 @@ class TestAllocZero:
 
 def test_local_IncSubtensor_serialize():
     d = np.random.normal(0, 0.01, size=(100, 100))
-    d = d.astype(theano.config.floatX)
+    d = d.astype(config.floatX)
 
     W = theano.shared(d, name="W")
     i = tt.vector("i", dtype="int64")
@@ -4238,9 +4238,7 @@ def test_local_subtensor_of_alloc():
     # DebugMode should detect if something goes wrong.
     # test shape combination of odd and event shape.
     for shape in [(3, 5), (4, 6), (3, 8), (4, 7), (1, 5), (5, 1)]:
-        x = tt.tensor(
-            dtype=theano.config.floatX, broadcastable=(shape[0] == 1, shape[1] == 1)
-        )
+        x = tt.tensor(dtype=config.floatX, broadcastable=(shape[0] == 1, shape[1] == 1))
 
         xval = np.zeros(shape, dtype=config.floatX)
         yval = np.arange(shape[1], dtype=config.floatX)
@@ -4276,7 +4274,7 @@ def test_local_subtensor_of_alloc():
             for slices in slicess:
                 z = yx.__getitem__(slices)
                 f = function([x], z)
-                if theano.config.mode != "FAST_COMPILE":
+                if config.mode != "FAST_COMPILE":
                     # Subtensor can be in the input of Alloc
                     assert not isinstance(f.maker.fgraph.toposort()[-1].op, Subtensor)
                 val = f(xval)
@@ -4583,7 +4581,7 @@ class TestLocalUselessElemwiseComparison:
         self.assert_eqs_const(f, 1)
 
     @pytest.mark.skipif(
-        theano.config.mode == "FAST_COMPILE",
+        config.mode == "FAST_COMPILE",
         reason="Skip opt test as the opt is disabled",
     )
     def test_equality_shapes(self):
@@ -4694,7 +4692,7 @@ class TestLocalCanonicalizeAlloc:
     def setup_method(self):
         self.rng = np.random.RandomState(utt.fetch_seed())
 
-    @change_flags(compute_test_value="off")
+    @config.change_flags(compute_test_value="off")
     def test_basic(self):
         x = shared(self.rng.randn(3, 7))
         a = tt.alloc(x, 6, 7)
@@ -4810,7 +4808,7 @@ class TestLocalUselessIncSubtensorAlloc:
     def setup_method(self):
         # The optimization requires the shape feature so we need to compile in
         # FAST_RUN mode.
-        mode = theano.config.mode
+        mode = config.mode
         if mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         self.mode = compile.mode.get_mode(mode)
@@ -4923,7 +4921,7 @@ class TestShapeOptimizer:
         utt.seed_rng()
 
     def test_basic(self):
-        mode = theano.config.mode
+        mode = config.mode
         if mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         v = tt.vector()
@@ -4933,7 +4931,7 @@ class TestShapeOptimizer:
             assert node.op != tt.add
 
     def test_constant(self):
-        mode = theano.config.mode
+        mode = config.mode
         if mode == "FAST_COMPILE":
             mode = "FAST_RUN"
 
@@ -5120,7 +5118,7 @@ class TestAssert(utt.InferShapeTester):
 
     def test_local_remove_useless_assert1(self):
         # remove assert that are always true
-        mode = theano.config.mode
+        mode = config.mode
         if mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         mode = compile.mode.get_mode(mode)
@@ -5135,7 +5133,7 @@ class TestAssert(utt.InferShapeTester):
 
     def test_test_local_remove_useless_assert2(self):
         # remove assert condition that are always true
-        mode = theano.config.mode
+        mode = config.mode
         if mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         mode = compile.mode.get_mode(mode)
@@ -5152,7 +5150,7 @@ class TestAssert(utt.InferShapeTester):
 
     def test_local_remove_useless_assert3(self):
         # don't remove assert condition that are always false
-        mode = theano.config.mode
+        mode = config.mode
         if mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         mode = compile.mode.get_mode(mode)
@@ -5169,7 +5167,7 @@ class TestAssert(utt.InferShapeTester):
 
     def test_local_remove_all_assert1(self):
         # remove assert condition that are unknown
-        mode = theano.config.mode
+        mode = config.mode
         if mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         mode = compile.mode.get_mode(mode).including("local_remove_all_assert")
@@ -5215,7 +5213,7 @@ class TestAssert(utt.InferShapeTester):
 
 
 def test_local_mul_specialize():
-    mode = theano.config.mode
+    mode = config.mode
     if mode == "FAST_COMPILE":
         mode = "FAST_RUN"
     mode = compile.mode.get_mode(mode)
@@ -5258,7 +5256,7 @@ class TestTile:
         v = tt.vector()
         m = tt.matrix()
         mode = None
-        if theano.config.mode == "FAST_COMPILE":
+        if config.mode == "FAST_COMPILE":
             mode = "FAST_RUN"
         for var, data in [(v, [1, 2, 3]), (m, [[1, 2], [3, 4]])]:
             # When len(repeat pattern) <= var.ndim, everything is removed
@@ -5314,15 +5312,15 @@ def speed_local_pow_specialize_range():
 
 
 def test_local_pow_specialize():
-    mode = theano.config.mode
+    mode = config.mode
     if mode == "FAST_COMPILE":
         mode = "FAST_RUN"
     mode = compile.mode.get_mode(mode)
     mode = mode.excluding("fusion")
 
     v = tt.vector()
-    val = np.arange(10, dtype=theano.config.floatX)
-    val_no0 = np.arange(1, 10, dtype=theano.config.floatX)
+    val = np.arange(10, dtype=config.floatX)
+    val_no0 = np.arange(1, 10, dtype=config.floatX)
 
     f = function([v], v ** 0, mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
@@ -5367,15 +5365,15 @@ def test_local_pow_specialize():
 
 
 def test_local_pow_specialize_device_more_aggressive_on_cpu():
-    mode = theano.config.mode
+    mode = config.mode
     if mode == "FAST_COMPILE":
         mode = "FAST_RUN"
     mode = compile.mode.get_mode(mode)
     mode = mode.excluding("fusion").excluding("gpu")
 
     v = tt.vector()
-    val = np.arange(10, dtype=theano.config.floatX)
-    val_no0 = np.arange(1, 10, dtype=theano.config.floatX)
+    val = np.arange(10, dtype=config.floatX)
+    val_no0 = np.arange(1, 10, dtype=config.floatX)
     f = function([v], v ** (15), mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
     assert len(nodes) == 1
@@ -5820,7 +5818,7 @@ class TestLocalSwitchSink:
 
 
 @pytest.mark.skipif(
-    theano.config.cxx == "" and not scal.basic_scipy.imported_scipy_special,
+    config.cxx == "" and not scal.basic_scipy.imported_scipy_special,
     reason="erf need a c++ compiler or scipy",
 )
 class TestLocalErf:
@@ -5918,7 +5916,7 @@ class TestLocalErf:
 
 
 @pytest.mark.skipif(
-    theano.config.cxx == "" and not scal.basic_scipy.imported_scipy_special,
+    config.cxx == "" and not scal.basic_scipy.imported_scipy_special,
     reason="erf need a c++ compiler or scipy",
 )
 class TestLocalErfc:
@@ -5985,7 +5983,7 @@ class TestLocalErfc:
     @pytest.mark.xfail()
     def test_local_log_erfc(self):
         val = [-30, -27, -26, -11, -10, -3, -2, -1, 0, 1, 2, 3, 10, 11, 26, 27, 28, 30]
-        if theano.config.mode in ["DebugMode", "DEBUG_MODE", "FAST_COMPILE"]:
+        if config.mode in ["DebugMode", "DEBUG_MODE", "FAST_COMPILE"]:
             # python mode don't like the inv(0)
             val.remove(0)
         val = np.asarray(val, dtype=config.floatX)
@@ -5999,17 +5997,17 @@ class TestLocalErfc:
 
         f = function([x], tt.log(tt.erfc(x)), mode=mode)
         assert len(f.maker.fgraph.apply_nodes) == 23, len(f.maker.fgraph.apply_nodes)
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
         assert all(np.isfinite(f(val)))
 
         f = function([x], tt.log(tt.erfc(-x)), mode=mode)
         assert len(f.maker.fgraph.apply_nodes) == 24, len(f.maker.fgraph.apply_nodes)
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
         assert all(np.isfinite(f(-val)))
 
         f = function([x], tt.log(tt.erfc(x)), mode=mode_fusion)
         assert len(f.maker.fgraph.apply_nodes) == 1, len(f.maker.fgraph.apply_nodes)
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
         assert (
             len(
                 f.maker.fgraph.toposort()[0]
@@ -6024,8 +6022,8 @@ class TestLocalErfc:
         )
         # TODO: fix this problem
         assert not (
-            theano.config.floatX == "float32"
-            and theano.config.mode
+            config.floatX == "float32"
+            and config.mode
             in [
                 "DebugMode",
                 "DEBUG_MODE",
@@ -6068,15 +6066,12 @@ class TestLocalErfc:
             30,
             100,
         ]
-        if theano.config.mode in ["DebugMode", "DEBUG_MODE", "FAST_COMPILE"]:
+        if config.mode in ["DebugMode", "DEBUG_MODE", "FAST_COMPILE"]:
             # python mode don't like the inv(0) in computation,
             # but the switch don't select this value.
             # So it is computed for no good reason.
             val.remove(0)
-        if (
-            theano.config.mode in ["DebugMode", "DEBUG_MODE"]
-            and theano.config.floatX == "float32"
-        ):
+        if config.mode in ["DebugMode", "DEBUG_MODE"] and config.floatX == "float32":
             # In float32 their is a plage of values close to 10 that we stabilize as it give bigger error then the stabilized version.
             # The orig value in float32 -30.0, the stab value -20.1 the orig value in float64 -18.1.
             val.remove(10)
@@ -6094,46 +6089,46 @@ class TestLocalErfc:
 
         assert len(f.maker.fgraph.apply_nodes) == 22, len(f.maker.fgraph.apply_nodes)
         assert all(np.isfinite(f(val)))
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
 
         # test with a different mul constant
         f = function(
             [x], tt.mul(tt.exp(tt.neg(tt.sqr(x))), -10.12837917) / tt.erfc(x), mode=mode
         )
         assert len(f.maker.fgraph.apply_nodes) == 23, len(f.maker.fgraph.apply_nodes)
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
         assert all(np.isfinite(f(val)))
 
         # test that we work without the mul
         f = function([x], tt.exp(tt.neg(tt.sqr(x))) / tt.erfc(x), mode=mode)
         assert len(f.maker.fgraph.apply_nodes) == 22, len(f.maker.fgraph.apply_nodes)
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
         assert all(np.isfinite(f(val)))
 
         # test that we don't work if x!=y
         f = function([x, y], tt.exp(tt.neg(tt.sqr(x))) / tt.erfc(y), mode=mode)
         assert len(f.maker.fgraph.apply_nodes) == 5, len(f.maker.fgraph.apply_nodes)
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
         f(val, val - 3)
 
         # test that we work without the sqr and neg
         f = function([x], tt.exp(tt.mul(-1, x, x)) / tt.erfc(x), mode=mode)
         assert len(f.maker.fgraph.apply_nodes) == 21, len(f.maker.fgraph.apply_nodes)
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
         assert all(np.isfinite(f(val)))
 
         # test that it work correctly if x is x*2 in the graph.
         f = function([x], tt.grad(tt.log(tt.erfc(2 * x)).sum(), x), mode=mode)
         assert len(f.maker.fgraph.apply_nodes) == 23, len(f.maker.fgraph.apply_nodes)
         assert np.isfinite(f(val)).all()
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
 
         f = function([x], tt.grad(tt.log(tt.erfc(x)).sum(), x), mode=mode_fusion)
         assert len(f.maker.fgraph.apply_nodes) == 1, len(f.maker.fgraph.apply_nodes)
-        assert f.maker.fgraph.outputs[0].dtype == theano.config.floatX
+        assert f.maker.fgraph.outputs[0].dtype == config.floatX
 
         # TODO: fix this problem
-        if theano.config.floatX == "float32" and theano.config.mode in [
+        if config.floatX == "float32" and config.mode in [
             "DebugMode",
             "DEBUG_MODE",
         ]:
@@ -6567,14 +6562,10 @@ class TestLocalSumProd:
         assert len(f.maker.fgraph.apply_nodes) == 1
         utt.assert_allclose(f(input), input.prod())
 
-        backup = config.warn__sum_sum_bug
-        config.warn__sum_sum_bug = False
-        try:
+        with config.change_flags(warn__sum_sum_bug=False):
             f = function([a], a.sum(0).sum(0).sum(0), mode=self.mode)
             assert len(f.maker.fgraph.apply_nodes) == 1
             utt.assert_allclose(f(input), input.sum())
-        finally:
-            config.warn__sum_sum_bug = backup
 
     def test_local_sum_sum_prod_prod(self):
         a = tt.tensor3()
@@ -6592,9 +6583,6 @@ class TestLocalSumProd:
             (1, (0, 1)),
             (2, (0, 1)),
         ]
-
-        backup = config.warn__sum_sum_bug
-        config.warn__sum_sum_bug = False
 
         def my_prod(data, d, dd):
             # This prod when d or dd is a tuple of 2 dimensions.
@@ -6629,7 +6617,7 @@ class TestLocalSumProd:
                 dd = sorted(dd)
                 return data.sum(d).prod(dd[1]).prod(dd[0])
 
-        try:
+        with config.change_flags(warn__sum_sum_bug=False):
             for d, dd in dims:
                 expected = my_sum(input, d, dd)
                 f = function([a], a.sum(d).sum(dd), mode=self.mode)
@@ -6646,8 +6634,6 @@ class TestLocalSumProd:
             f = function([a], a.sum(None).sum(), mode=self.mode)
             utt.assert_allclose(f(input), input.sum())
             assert len(f.maker.fgraph.apply_nodes) == 1
-        finally:
-            config.warn__sum_sum_bug = backup
 
         # test prod
         for d, dd in dims:
@@ -6743,9 +6729,7 @@ class TestLocalSumProd:
                 assert topo[-1].op == tt.alloc
                 assert not any([isinstance(node.op, Prod) for node in topo])
 
-            backup = config.warn__sum_sum_bug
-            config.warn__sum_sum_bug = False
-            try:
+            with config.change_flags(warn__sum_sum_bug=False):
                 for d, dd in [(0, 0), (1, 0), (2, 0), (0, 1), (1, 1), (2, 1)]:
                     f = function([a], t_like(a).sum(d).sum(dd), mode=mode)
                     utt.assert_allclose(f(input), n_like(input).sum(d).sum(dd))
@@ -6753,36 +6737,27 @@ class TestLocalSumProd:
                     topo = f.maker.fgraph.toposort()
                     assert topo[-1].op == tt.alloc
                     assert not any([isinstance(node.op, tt.Sum) for node in topo])
-            finally:
-                config.warn__sum_sum_bug = backup
 
     def test_local_sum_sum_int8(self):
         # Test that local_sum_sum works when combining two sums on an int8 array.
         # This is a regression test for ticket gh-356.
 
         x = tt.tensor3(dtype="int8")
-
         y = x.sum(axis=0).sum(axis=1)
-        backup = config.on_opt_error
-        config.on_opt_error = "raise"
-        try:
+
+        with config.change_flags(on_opt_error="raise"):
             # This compilation would fail prior to fix.
             function([x], y)
-        finally:
-            config.on_opt_error = backup
 
     def test_local_sum_sum_dtype(self):
         # Test that local_sum_sum works when specifying dtypes manually.
 
         x = tt.tensor3(dtype="int8")
         y = x.sum(axis=0, dtype="int32").sum(axis=1, dtype="int64")
-        backup = config.on_opt_error
-        config.on_opt_error = "raise"
-        try:
+
+        with config.change_flags(on_opt_error="raise"):
             # This compilation would fail prior to fix.
             function([x], y)
-        finally:
-            config.on_opt_error = backup
 
     def test_local_sum_prod_mul_by_scalar_stack_trace(self):
         # Test that stack trace is copied over correctly for local_sum_prod_mul_by_scalar.
@@ -6821,26 +6796,19 @@ class TestLocalOptAlloc:
     def test_sum_upcast(self):
         s = tt.lscalar()
         a = tt.alloc(np.asarray(5, dtype=self.dtype), s, s)
-        orig = theano.config.warn_float64
-        theano.config.warn_float64 = "raise"
-        try:
+        with config.change_flags(warn_float64="raise"):
             f = function([s], a.sum())
             f(5)
-        finally:
-            theano.config.warn_float64 = orig
 
     def test_prod_upcast(self):
         s = tt.lscalar()
         a = tt.alloc(np.asarray(5, dtype=self.dtype), s, s)
-        orig = theano.config.warn_float64
-        theano.config.warn_float64 = "raise"
-        try:
+
+        with config.change_flags(warn_float64="raise"):
             f = function([s], a.prod())
             f(5)
-        finally:
-            theano.config.warn_float64 = orig
 
-    @change_flags(on_opt_error="raise")
+    @config.change_flags(on_opt_error="raise")
     def test_sum_bool_upcast(self):
         s = tt.lscalar()
         a = tt.alloc(np.asarray(True, dtype="bool"), s, s)
@@ -6852,7 +6820,6 @@ class TestLocalOptAlloc:
         # test only 1 axis summed
         f = function([s], a.sum(axis=0, dtype=self.dtype))
         f(5)
-        print(self.dtype)
 
 
 class TestLocalOptAllocF16(TestLocalOptAlloc):
@@ -6967,12 +6934,9 @@ class TestLocalReduce:
         assert isinstance(topo[-1].op, tt.Elemwise)
 
         # Test a case that was bugged in a old Theano bug
-        try:
-            old = theano.config.warn__reduce_join
-            theano.config.warn__reduce_join = False
+        with config.change_flags(warn__reduce_join=False):
             f = function([], tt.sum(tt.stack([A, A]), axis=1), mode=self.mode)
-        finally:
-            theano.config.warn__reduce_join = old
+
         utt.assert_allclose(f(), [15, 15])
         topo = f.maker.fgraph.toposort()
         assert not isinstance(topo[-1].op, tt.Elemwise)
@@ -6993,13 +6957,9 @@ class TestLocalReduce:
         # Test that the optimization does not crash in one case where it
         # is not applied.  Reported at
         # https://groups.google.com/d/topic/theano-users/EDgyCU00fFA/discussion
-        old = theano.config.warn__reduce_join
-        try:
-            theano.config.warn__reduce_join = False
+        with config.change_flags(warn__reduce_join=False):
             out = tt.sum([vx, vy, vz], axis=None)
             f = function([vx, vy, vz], out)
-        finally:
-            theano.config.warn__reduce_join = old
 
 
 class TestLocalSumProdDimshuffle:
@@ -7053,18 +7013,14 @@ class TestLocalSumProdDimshuffle:
         c_val = rng.randn(2, 2, 2).astype(config.floatX)
         d_val = np.asarray(rng.randn(), config.floatX)
 
-        backup = config.warn__sum_sum_bug, config.warn__sum_div_dimshuffle_bug
-        config.warn__sum_sum_bug = False
-        config.warn__sum_div_dimshuffle_bug = False
-        try:
+        with config.change_flags(
+            warn__sum_sum_bug=False, warn__sum_div_dimshuffle_bug=False
+        ):
             for i, s in enumerate(sums):
-                print(i)
                 f = function([a, b, c, d], s, mode=self.mode, on_unused_input="ignore")
                 g = f.maker.fgraph.toposort()
                 assert isinstance(g[-1].op.scalar_op, scal.basic.TrueDiv)
                 f(a_val, b_val, c_val, d_val)
-        finally:
-            config.warn__sum_sum_bug, config.warn__sum_div_dimshuffle_bug = backup
 
     def test_local_prod_div_dimshuffle(self):
         a = tt.matrix("a")
@@ -7755,13 +7711,9 @@ def test_local_upcast_elemwise_constant_inputs():
     f([-42, -2.1, -1, -0.5, 0, 0.2, 1, 2, 12])
 
     # This test a corner where the optimization should not be applied.
-    old = theano.config.floatX
-    theano.config.floatX = "float32"
-    try:
+    with config.change_flags(floatX="float32"):
         v = lvector()
         function([v], tt.true_div(v, 2))
-    finally:
-        theano.config.floatX = old
 
 
 class TestShapeI(utt.InferShapeTester):
@@ -7852,7 +7804,7 @@ def test_assert_op_gradient():
     grad = tt.grad(cost, x)
     func = function([x], grad)
 
-    x_val = np.ones(shape=(1,), dtype=theano.config.floatX)
+    x_val = np.ones(shape=(1,), dtype=config.floatX)
     assert func(x_val) == 1
 
 

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -4,7 +4,7 @@ from tempfile import mkdtemp
 import numpy as np
 import pytest
 
-from theano import change_flags, config
+from theano import config
 from theano.tensor.type import TensorType
 
 
@@ -42,7 +42,7 @@ def test_filter_ndarray_subclass():
 
 def test_filter_float_subclass():
     """Make sure `TensorType.filter` can handle `float` subclasses."""
-    with change_flags(floatX="float64"):
+    with config.change_flags(floatX="float64"):
         test_type = TensorType("float64", broadcastable=[])
 
         nan = np.array([np.nan], dtype="float64")[0]
@@ -51,7 +51,7 @@ def test_filter_float_subclass():
         filtered_nan = test_type.filter(nan)
         assert isinstance(filtered_nan, np.ndarray)
 
-    with change_flags(floatX="float32"):
+    with config.change_flags(floatX="float32"):
         # Try again, except this time `nan` isn't a `float`
         test_type = TensorType("float32", broadcastable=[])
 

--- a/tests/tensor/utils.py
+++ b/tests/tensor/utils.py
@@ -8,7 +8,7 @@ import pytest
 
 import theano
 from tests import unittest_tools as utt
-from theano import change_flags, config, function, gof, shared, tensor
+from theano import config, function, gof, shared, tensor
 from theano.compile.mode import get_default_mode
 from theano.tensor.type import TensorType
 
@@ -16,7 +16,7 @@ from theano.tensor.type import TensorType
 # Used to exclude random numbers too close to certain values
 _eps = 1e-2
 
-if theano.config.floatX == "float32":
+if config.floatX == "float32":
     angle_eps = 1e-4
 else:
     angle_eps = 1e-10
@@ -572,7 +572,7 @@ def makeTester(
                 # instantiated on the following bad inputs: %s"
                 # % (self.op, testname, node, inputs))
 
-        @change_flags(compute_test_value="off")
+        @config.change_flags(compute_test_value="off")
         @pytest.mark.skipif(skip, reason="Skipped")
         def test_bad_runtime(self):
             for testname, inputs in self.bad_runtime.items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,33 @@ def test_api_deprecation_warning():
             pass
 
 
+def test_api_redirect():
+    root = configdefaults.config
+    # one section level
+    root.add(
+        "test__section_redirect",
+        "A config var from a test case.",
+        configparser.StrParam("test_default"),
+    )
+    assert hasattr(root, "test__section_redirect")
+    assert root.test__section_redirect == "test_default"
+    assert hasattr(root, "test")
+    assert isinstance(root.test, configparser._SectionRedirect)
+    with pytest.warns(DeprecationWarning):
+        assert root.test.section_redirect == "test_default"
+
+    # two section levels
+    root.add(
+        "test__subsection__redirect",
+        "A config var from a test case.",
+        configparser.StrParam("test_default2"),
+    )
+    assert hasattr(root, "test__subsection__redirect")
+    assert root.test__subsection__redirect == "test_default2"
+    with pytest.warns(DeprecationWarning):
+        assert root.test.subsection.redirect == "test_default2"
+
+
 def test_invalid_default():
     # Ensure an invalid default value found in the Theano code only causes
     # a crash if it is not overridden by the user.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,25 @@ from theano.configdefaults import default_blas_ldflags
 from theano.configparser import ConfigParam
 
 
+def test_api_deprecation_warning():
+    # accessing through configdefaults.config is the new best practice
+    with pytest.warns(None):
+        root = configdefaults.config
+        assert isinstance(str(root), str)
+
+    # accessing through configparser.config is discouraged
+    root = configparser.config
+    with pytest.warns(DeprecationWarning, match="instead"):
+        root.add(
+            "test_deprecationwarning",
+            "A config var from a test case.",
+            configparser.StrParam("test_default"),
+        )
+    with pytest.warns(DeprecationWarning, match="instead"):
+        with root.change_flags(test_deprecationwarning="new_value"):
+            pass
+
+
 def test_invalid_default():
     # Ensure an invalid default value found in the Theano code only causes
     # a crash if it is not overridden by the user.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,6 +103,12 @@ def test_config_hash():
     assert h2 == h0
 
 
+def test_config_print():
+    root = configparser.config
+    result = str(root)
+    assert isinstance(result, str)
+
+
 class TestConfigTypes:
     def test_bool(self):
         valids = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,6 +158,9 @@ def test_config_context():
 
     with configparser.change_flags(test_config_context="new_value"):
         assert root.test_config_context == "new_value"
+        with root.change_flags({"test_config_context": "new_value2"}):
+            assert root.test_config_context == "new_value2"
+        assert root.test_config_context == "new_value"
     assert root.test_config_context == "test_default"
 
 

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -5,7 +5,7 @@ import pytest
 
 import theano
 from tests import unittest_tools as utt
-from theano import change_flags, config, gof, gradient
+from theano import config, gof, gradient
 from theano.gof.null_type import NullType
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 
@@ -521,7 +521,7 @@ def test_known_grads_integers():
     f = theano.function([g_expected], g_grad)
 
     x = -3
-    gv = np.cast[theano.config.floatX](0.6)
+    gv = np.cast[config.floatX](0.6)
 
     g_actual = f(gv)
 
@@ -784,7 +784,7 @@ def test_grad_clip():
 
     f = theano.function([x], outputs=[z, z2])
 
-    if theano.config.mode != "FAST_COMPILE":
+    if config.mode != "FAST_COMPILE":
         topo = f.maker.fgraph.toposort()
         assert not any([isinstance(node.op, gradient.GradClip) for node in topo])
     out = f(2.0)
@@ -800,7 +800,7 @@ def test_grad_scale():
 
     f = theano.function([x], outputs=[z, z2])
 
-    if theano.config.mode != "FAST_COMPILE":
+    if config.mode != "FAST_COMPILE":
         topo = f.maker.fgraph.toposort()
         assert not any([isinstance(node.op, gradient.GradScale) for node in topo])
     out = f(2.0)
@@ -808,11 +808,11 @@ def test_grad_scale():
     assert np.allclose(out, (8, 4))
 
 
-@change_flags(compute_test_value="off")
+@config.change_flags(compute_test_value="off")
 def test_undefined_grad_opt():
     # Make sure that undefined grad get removed in optimized graph.
     random = RandomStreams(np.random.randint(1, 2147462579))
-    pvals = theano.shared(np.random.rand(10, 20).astype(theano.config.floatX))
+    pvals = theano.shared(np.random.rand(10, 20).astype(config.floatX))
     pvals = pvals / pvals.sum(axis=1)
     pvals = gradient.zero_grad(pvals)
     samples = random.multinomial(pvals=pvals, n=1)

--- a/theano/__init__.py
+++ b/theano/__init__.py
@@ -64,7 +64,12 @@ for p in sys.path:
     raise RuntimeError("You have the theano directory in your Python path.")
 
 from theano.configdefaults import config
-from theano.configparser import change_flags
+from theano.utils import deprecated
+
+
+change_flags = deprecated("Use theano.config.change_flags instead!")(
+    config.change_flags
+)
 
 
 # This is the api version for ops that generate C code.  External ops

--- a/theano/compile/builders.py
+++ b/theano/compile/builders.py
@@ -401,7 +401,7 @@ class OpFromGraph(Op):
         is_inline = self.is_inline
         return "%(name)s{inline=%(is_inline)s}" % locals()
 
-    @theano.change_flags(compute_test_value="off")
+    @theano.config.change_flags(compute_test_value="off")
     def _recompute_lop_op(self):
         """
         converts self._lop_op from user supplied form to type(self) instance
@@ -541,7 +541,7 @@ class OpFromGraph(Op):
         self._lop_op_is_cached = True
         self._lop_type = "lop"
 
-    @theano.change_flags(compute_test_value="off")
+    @theano.config.change_flags(compute_test_value="off")
     def _recompute_rop_op(self):
         """
         converts self._rop_op from user supplied form to type(self) instance

--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -18,7 +18,7 @@ from warnings import warn
 import numpy as np
 
 import theano
-from theano import change_flags, config, gof
+from theano import config, gof
 from theano.compile.function.types import (
     Function,
     FunctionMaker,
@@ -2446,7 +2446,7 @@ class _Maker(FunctionMaker):  # inheritance buys a few helper functions
             )
             fgraph.equivalence_tracker = equivalence_tracker
 
-            with change_flags(compute_test_value=config.compute_test_value_opt):
+            with config.change_flags(compute_test_value=config.compute_test_value_opt):
                 optimizer(fgraph)
 
                 theano.compile.function.types.insert_deepcopy(
@@ -2506,7 +2506,7 @@ class _Maker(FunctionMaker):  # inheritance buys a few helper functions
                             file=sys.stderr,
                         )
         self.fgraph = fgraph
-        if theano.config.cycle_detection == "regular":
+        if config.cycle_detection == "regular":
             destroy_handler_added = False
             for feature in fgraph._features:
                 if isinstance(feature, gof.DestroyHandler):
@@ -2516,7 +2516,9 @@ class _Maker(FunctionMaker):  # inheritance buys a few helper functions
                 fgraph.attach_feature(gof.DestroyHandler())
             for o in fgraph.outputs:
                 try:
-                    with change_flags(compute_test_value=config.compute_test_value_opt):
+                    with config.change_flags(
+                        compute_test_value=config.compute_test_value_opt
+                    ):
                         fgraph.replace_validate(
                             o, _output_guard(o), reason="output_guard"
                         )

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -12,8 +12,8 @@ import warnings
 import numpy as np
 
 import theano
+import theano.configparser
 from theano.configparser import (
-    THEANO_FLAGS_DICT,
     AddConfigVar,
     BoolParam,
     ConfigParam,
@@ -23,7 +23,6 @@ from theano.configparser import (
     FloatParam,
     IntParam,
     StrParam,
-    TheanoConfigParser,
 )
 from theano.misc.windows import call_subprocess_Popen, output_subprocess_Popen
 from theano.utils import maybe_add_to_os_environ_pathlist
@@ -2236,7 +2235,7 @@ SUPPORTED_DNN_CONV_PRECISION = (
 # TODO: we should add the configs explicitly to an instance of the TheanoConfigParser
 # Even if we treat it as a singleton, we should implement as if it wasn't, so we can
 # test it independently.
-config = TheanoConfigParser()
+config = theano.configparser.config
 add_basic_configvars()
 add_dnn_configvars()
 add_magma_configvars()
@@ -2272,6 +2271,5 @@ except OSError:
 add_caching_dir_configvars()
 
 # Check if there are remaining flags provided by the user through THEANO_FLAGS.
-# TODO: the global variable THEANO_FLAGS_DICT should probably become an attribute on the `config` singleton
-for key in THEANO_FLAGS_DICT.keys():
+for key in config._flags_dict.keys():
     warnings.warn(f"Theano does not recognise this flag: {key}")

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -14,7 +14,6 @@ import numpy as np
 import theano
 import theano.configparser
 from theano.configparser import (
-    AddConfigVar,
     BoolParam,
     ConfigParam,
     ContextsParam,
@@ -617,7 +616,7 @@ def short_platform(r=None, p=None):
 
 def add_basic_configvars():
 
-    AddConfigVar(
+    config.add(
         "floatX",
         "Default floating-point precision for python casts.\n"
         "\n"
@@ -627,7 +626,7 @@ def add_basic_configvars():
         in_c_key=True,
     )
 
-    AddConfigVar(
+    config.add(
         "warn_float64",
         "Do an action when a tensor variable with float64 dtype is"
         " created. They can't be run on the GPU with the current(old)"
@@ -636,7 +635,7 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "pickle_test_value",
         "Dump test values while pickling model. "
         "If True, test values will be dumped with model.",
@@ -644,7 +643,7 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "cast_policy",
         "Rules for implicit type casting",
         EnumStr(
@@ -665,7 +664,7 @@ def add_basic_configvars():
     # numpy 1.6.1 behaves as python 2.*. I think we should not change it faster
     # than numpy. When we will do the transition, we should create an int_warn
     # and floatX_warn option.
-    AddConfigVar(
+    config.add(
         "int_division",
         "What to do when one computes x / y, where both x and y are of "
         "integer types",
@@ -673,7 +672,7 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "deterministic",
         "If `more`, sometimes we will select some implementation that "
         "are more deterministic, but slower. In particular, on the GPU, "
@@ -685,7 +684,7 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "device",
         (
             "Default device for computations. If cuda* or opencl*, change the"
@@ -698,7 +697,7 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "init_gpu_device",
         (
             "Initialize the gpu device to use, works only if device=cpu. "
@@ -710,14 +709,14 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "force_device",
         "Raise an error if we can't use the specified device",
         BoolParam(False, mutable=False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "conv__assert_shape",
         "If True, AbstractConv* ops will verify that user-provided"
         " shapes match the runtime shapes (debugging option,"
@@ -726,14 +725,14 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "print_global_stats",
         "Print some global statistics (time spent) at the end",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "contexts",
         """
         Context map for multi-gpu operation. Format is a
@@ -748,14 +747,14 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "print_active_device",
         "Print active device at when the GPU device is initialized.",
         BoolParam(True, mutable=False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "gpuarray__preallocate",
         """If negative it disables the allocation cache. If
                  between 0 and 1 it enables the allocation cache and
@@ -766,7 +765,7 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "gpuarray__sched",
         """The sched parameter passed for context creation to pygpu.
                     With CUDA, using "multi" is equivalent to using the parameter
@@ -777,7 +776,7 @@ def add_basic_configvars():
         EnumStr("default", ["multi", "single"]),
     )
 
-    AddConfigVar(
+    config.add(
         "gpuarray__single_stream",
         """
                  If your computations are mostly lots of small elements,
@@ -792,14 +791,14 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "cuda__root",
         "Location of the cuda installation",
         StrParam(get_cuda_root),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "cuda__include_path",
         "Location of the cuda includes",
         StrParam(default_cuda_include),
@@ -808,13 +807,13 @@ def add_basic_configvars():
 
     # This flag determines whether or not to raise error/warning message if
     # there is a CPU Op in the computational graph.
-    AddConfigVar(
+    config.add(
         "assert_no_cpu_op",
         "Raise an error/warning if there is a CPU op in the computational graph.",
         EnumStr("ignore", ["warn", "raise", "pdb"], mutable=True),
         in_c_key=False,
     )
-    AddConfigVar(
+    config.add(
         "unpickle_function",
         (
             "Replace unpickled Theano functions with None. "
@@ -825,7 +824,7 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "reoptimize_unpickled_function",
         "Re-optimize the graph when a theano function is unpickled from the disk.",
         BoolParam(False, mutable=True),
@@ -834,14 +833,14 @@ def add_basic_configvars():
 
 
 def add_dnn_configvars():
-    AddConfigVar(
+    config.add(
         "dnn__conv__algo_fwd",
         "Default implementation to use for cuDNN forward convolution.",
         EnumStr("small", SUPPORTED_DNN_CONV_ALGO_FWD),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "dnn__conv__algo_bwd_data",
         "Default implementation to use for cuDNN backward convolution to "
         "get the gradients of the convolution with regard to the inputs.",
@@ -849,7 +848,7 @@ def add_dnn_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "dnn__conv__algo_bwd_filter",
         "Default implementation to use for cuDNN backward convolution to "
         "get the gradients of the convolution with regard to the "
@@ -858,7 +857,7 @@ def add_dnn_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "dnn__conv__precision",
         "Default data precision to use for the computation in cuDNN "
         "convolutions (defaults to the same dtype as the inputs of the "
@@ -867,28 +866,28 @@ def add_dnn_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "dnn__base_path",
         "Install location of cuDNN.",
         StrParam(default_dnn_base_path),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "dnn__include_path",
         "Location of the cudnn header",
         StrParam(default_dnn_inc_path),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "dnn__library_path",
         "Location of the cudnn link library.",
         StrParam(default_dnn_lib_path),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "dnn__bin_path",
         "Location of the cuDNN load library "
         "(on non-windows platforms, "
@@ -897,7 +896,7 @@ def add_dnn_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "dnn__enabled",
         "'auto', use cuDNN if available, but silently fall back"
         " to not using it if not present."
@@ -910,21 +909,21 @@ def add_dnn_configvars():
 
 
 def add_magma_configvars():
-    AddConfigVar(
+    config.add(
         "magma__include_path",
         "Location of the magma header",
         StrParam(""),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "magma__library_path",
         "Location of the magma library",
         StrParam(""),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "magma__enabled",
         " If True, use magma for matrix computation." " If False, disable magma",
         BoolParam(False),
@@ -934,7 +933,7 @@ def add_magma_configvars():
 
 def add_compile_configvars():
 
-    AddConfigVar(
+    config.add(
         "mode",
         "Default compilation mode",
         ConfigParam("Mode", apply=filter_mode),
@@ -994,7 +993,7 @@ def add_compile_configvars():
     if param and os.name == "nt":
         param = f'"{param}"'
 
-    AddConfigVar(
+    config.add(
         "cxx",
         "The C++ compiler to use. Currently only g++ is"
         " supported, but supporting additional compilers should not be "
@@ -1007,7 +1006,7 @@ def add_compile_configvars():
 
     if rc == 0 and config.cxx != "":
         # Keep the default linker the same as the one for the mode FAST_RUN
-        AddConfigVar(
+        config.add(
             "linker",
             "Default linker used if the theano flags mode is Mode",
             EnumStr(
@@ -1018,7 +1017,7 @@ def add_compile_configvars():
     else:
         # g++ is not present or the user disabled it,
         # linker should default to python only.
-        AddConfigVar(
+        config.add(
             "linker",
             "Default linker used if the theano flags mode is Mode",
             EnumStr("vm", ["py", "vm_nogc"]),
@@ -1035,7 +1034,7 @@ def add_compile_configvars():
             )
 
     # Keep the default value the same as the one for the mode FAST_RUN
-    AddConfigVar(
+    config.add(
         "allow_gc",
         "Do we default to delete intermediate results during Theano"
         " function calls? Doing so lowers the memory requirement, but"
@@ -1047,7 +1046,7 @@ def add_compile_configvars():
     )
 
     # Keep the default optimizer the same as the one for the mode FAST_RUN
-    AddConfigVar(
+    config.add(
         "optimizer",
         "Default optimizer. If not None, will use this optimizer with the Mode",
         EnumStr(
@@ -1057,14 +1056,14 @@ def add_compile_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "optimizer_verbose",
         "If True, we print all optimization being applied",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "on_opt_error",
         (
             "What to do when an optimization crashes: warn and skip it, raise "
@@ -1074,14 +1073,14 @@ def add_compile_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "nocleanup",
         "Suppress the deletion of code files that did not compile cleanly",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "on_unused_input",
         "What to do if a variable in the 'inputs' list of "
         " theano.function() is not used in the graph.",
@@ -1089,7 +1088,7 @@ def add_compile_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "gcc__cxxflags",
         "Extra compiler flags for gcc",
         StrParam(""),
@@ -1097,7 +1096,7 @@ def add_compile_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "cmodule__warn_no_version",
         "If True, will print a warning when compiling one or more Op "
         "with C code that can't be cached because there is no "
@@ -1107,7 +1106,7 @@ def add_compile_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "cmodule__remove_gxx_opt",
         "If True, will remove the -O* parameter passed to g++."
         "This is useful to debug in gdb modules compiled by Theano."
@@ -1118,21 +1117,21 @@ def add_compile_configvars():
         in_c_key=True,
     )
 
-    AddConfigVar(
+    config.add(
         "cmodule__compilation_warning",
         "If True, will print compilation warnings.",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "cmodule__preload_cache",
         "If set to True, will preload the C module cache at import time",
         BoolParam(False, mutable=False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "cmodule__age_thresh_use",
         "In seconds. The time after which " "Theano won't reuse a compile c module.",
         # 24 days
@@ -1140,21 +1139,21 @@ def add_compile_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "cmodule__debug",
         "If True, define a DEBUG macro (if not exists) for any compiled C code.",
         BoolParam(False),
         in_c_key=True,
     )
 
-    AddConfigVar(
+    config.add(
         "compile__wait",
         """Time to wait before retrying to acquire the compile lock.""",
         IntParam(5, validate=lambda i: i > 0, mutable=False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "compile__timeout",
         """In seconds, time that a process will wait before deciding to
     override an existing lock. An override only happens when the existing
@@ -1165,7 +1164,7 @@ def add_compile_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "ctc__root",
         "Directory which contains the root of Baidu CTC library. It is assumed \
         that the compiled library is either inside the build, lib or lib64 \
@@ -1181,14 +1180,14 @@ def add_tensor_configvars():
     # So changing it after import will not modify these global variables.
     # This could be done differently... but for now we simply prevent it from being
     # changed at runtime.
-    AddConfigVar(
+    config.add(
         "tensor__cmp_sloppy",
         "Relax tensor._allclose (0) not at all, (1) a bit, (2) more",
         IntParam(0, lambda i: i in (0, 1, 2), mutable=False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "tensor__local_elemwise_fusion",
         (
             "Enable or not in fast_run mode(fast_run optimization) the elemwise "
@@ -1199,7 +1198,7 @@ def add_tensor_configvars():
     )
 
     # http://developer.amd.com/CPU/LIBRARIES/LIBM/Pages/default.aspx
-    AddConfigVar(
+    config.add(
         "lib__amblibm",
         "Use amd's amdlibm numerical library",
         BoolParam(False),
@@ -1207,7 +1206,7 @@ def add_tensor_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "tensor__insert_inplace_optimizer_validate_nb",
         "-1: auto, if graph have less then 500 nodes 1, else 10",
         IntParam(-1),
@@ -1216,7 +1215,7 @@ def add_tensor_configvars():
 
 
 def add_traceback_configvars():
-    AddConfigVar(
+    config.add(
         "traceback__limit",
         "The number of stack to trace. -1 mean all.",
         # We default to a number to be able to know where v1 + v2 is created in the
@@ -1230,7 +1229,7 @@ def add_traceback_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "traceback__compile_limit",
         "The number of stack to trace to keep during compilation. -1 mean all."
         " If greater then 0, will also make us save Theano internal stack trace.",
@@ -1240,7 +1239,7 @@ def add_traceback_configvars():
 
 
 def add_experimental_configvars():
-    AddConfigVar(
+    config.add(
         "experimental__unpickle_gpu_on_cpu",
         "Allow unpickling of pickled GpuArrays as numpy.ndarrays."
         "This is useful, if you want to open a GpuArray without "
@@ -1255,7 +1254,7 @@ def add_experimental_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "experimental__local_alloc_elemwise",
         "DEPRECATED: If True, enable the experimental"
         " optimization local_alloc_elemwise."
@@ -1267,7 +1266,7 @@ def add_experimental_configvars():
     )
 
     # False could make the graph faster but not as safe.
-    AddConfigVar(
+    config.add(
         "experimental__local_alloc_elemwise_assert",
         "When the local_alloc_elemwise is applied, add"
         " an assert to highlight shape errors.",
@@ -1277,7 +1276,7 @@ def add_experimental_configvars():
 
 
 def add_error_and_warning_configvars():
-    AddConfigVar(
+    config.add(
         "numpy__seterr_all",
         (
             "Sets numpy's behaviour for floating-point errors, ",
@@ -1295,7 +1294,7 @@ def add_error_and_warning_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "numpy__seterr_divide",
         (
             "Sets numpy's behavior for division by zero, see numpy.seterr. "
@@ -1307,7 +1306,7 @@ def add_error_and_warning_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "numpy__seterr_over",
         (
             "Sets numpy's behavior for floating-point overflow, "
@@ -1320,7 +1319,7 @@ def add_error_and_warning_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "numpy__seterr_under",
         (
             "Sets numpy's behavior for floating-point underflow, "
@@ -1333,7 +1332,7 @@ def add_error_and_warning_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "numpy__seterr_invalid",
         (
             "Sets numpy's behavior for invalid floating-point operation, "
@@ -1349,7 +1348,7 @@ def add_error_and_warning_configvars():
     ###
     # To disable some warning about old bug that are fixed now.
     ###
-    AddConfigVar(
+    config.add(
         "warn__ignore_bug_before",
         (
             "If 'None', we warn about all Theano bugs found by default. "
@@ -1392,7 +1391,7 @@ def add_error_and_warning_configvars():
     # method when exception_verbosity == 'low'. When exception_verbosity
     # == 'high', you should include a call to printing.min_informative_str
     # on all important apply nodes.
-    AddConfigVar(
+    config.add(
         "exception_verbosity",
         "If 'low', the text of exceptions will generally refer "
         "to apply nodes with short names such as "
@@ -1408,7 +1407,7 @@ def add_error_and_warning_configvars():
 
 
 def add_testvalue_and_checking_configvars():
-    AddConfigVar(
+    config.add(
         "print_test_value",
         (
             "If 'True', the __eval__ of a Theano variable will return its test_value "
@@ -1420,7 +1419,7 @@ def add_testvalue_and_checking_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "compute_test_value",
         (
             "If 'True', Theano will run each op at graph build time, using "
@@ -1432,7 +1431,7 @@ def add_testvalue_and_checking_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "compute_test_value_opt",
         (
             "For debugging Theano optimization only."
@@ -1442,7 +1441,7 @@ def add_testvalue_and_checking_configvars():
         EnumStr("off", ["ignore", "warn", "raise", "pdb"]),
         in_c_key=False,
     )
-    AddConfigVar(
+    config.add(
         "check_input",
         "Specify if types should check their input in their C code. "
         "It can be used to speed up compilation, reduce overhead "
@@ -1451,63 +1450,63 @@ def add_testvalue_and_checking_configvars():
         BoolParam(True),
         in_c_key=True,
     )
-    AddConfigVar(
+    config.add(
         "NanGuardMode__nan_is_error",
         "Default value for nan_is_error",
         BoolParam(True),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "NanGuardMode__inf_is_error",
         "Default value for inf_is_error",
         BoolParam(True),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "NanGuardMode__big_is_error",
         "Default value for big_is_error",
         BoolParam(True),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "NanGuardMode__action",
         "What NanGuardMode does when it finds a problem",
         EnumStr("raise", ["warn", "pdb"]),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "DebugMode__patience",
         "Optimize graph this many times to detect inconsistency",
         IntParam(10, lambda i: i > 0),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "DebugMode__check_c",
         "Run C implementations where possible",
         BoolParam(lambda: bool(theano.config.cxx)),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "DebugMode__check_py",
         "Run Python implementations where possible",
         BoolParam(True),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "DebugMode__check_finite",
         "True -> complain about NaN/Inf results",
         BoolParam(True),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "DebugMode__check_strides",
         (
             "Check that Python- and C-produced ndarrays have same strides. "
@@ -1517,7 +1516,7 @@ def add_testvalue_and_checking_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "DebugMode__warn_input_not_reused",
         (
             "Generate a warning when destroy_map or view_map says that an "
@@ -1528,7 +1527,7 @@ def add_testvalue_and_checking_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "DebugMode__check_preallocated_output",
         (
             "Test thunks with pre-allocated memory as output storage. "
@@ -1544,7 +1543,7 @@ def add_testvalue_and_checking_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "DebugMode__check_preallocated_output_ndim",
         (
             'When testing with "strided" preallocated output memory, '
@@ -1557,35 +1556,35 @@ def add_testvalue_and_checking_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__time_thunks",
         """Time individual thunks when profiling""",
         BoolParam(True),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__n_apply",
         "Number of Apply instances to print by default",
         IntParam(20, lambda i: i > 0),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__n_ops",
         "Number of Ops to print by default",
         IntParam(20, lambda i: i > 0),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__output_line_width",
         "Max line width for the profiling output",
         IntParam(512, lambda i: i > 0),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__min_memory_size",
         """For the memory profile, do not print Apply nodes if the size
                  of their outputs (in bytes) is lower than this threshold""",
@@ -1593,35 +1592,35 @@ def add_testvalue_and_checking_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__min_peak_memory",
         """The min peak memory usage of the order""",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__destination",
         """File destination of the profiling output""",
         StrParam("stderr"),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__debugprint",
         """Do a debugprint of the profiled functions""",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profiling__ignore_first_call",
         """Do we ignore the first call of a Theano function.""",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "on_shape_error",
         "warn: print a warning and use the default" " value. raise: raise an error",
         EnumStr("warn", ["raise"]),
@@ -1659,7 +1658,7 @@ def add_multiprocessing_configvars():
     # too small convolution.
     default_openmp = False
 
-    AddConfigVar(
+    config.add(
         "openmp",
         "Allow (or not) parallel computation on the CPU with OpenMP. "
         "This is the default value used when creating an Op that "
@@ -1675,7 +1674,7 @@ def add_multiprocessing_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "openmp_elemwise_minsize",
         "If OpenMP is enabled, this is the minimum size of vectors "
         "for which the openmp parallelization is enabled "
@@ -1686,7 +1685,7 @@ def add_multiprocessing_configvars():
 
 
 def add_optimizer_configvars():
-    AddConfigVar(
+    config.add(
         "optimizer_excluding",
         (
             "When using the default mode, we will remove optimizer with "
@@ -1696,7 +1695,7 @@ def add_optimizer_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "optimizer_including",
         (
             "When using the default mode, we will add optimizer with "
@@ -1706,7 +1705,7 @@ def add_optimizer_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "optimizer_requiring",
         (
             "When using the default mode, we will require optimizer with "
@@ -1716,7 +1715,7 @@ def add_optimizer_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "optdb__position_cutoff",
         "Where to stop eariler during optimization. It represent the"
         " position of the optimizer where to stop.",
@@ -1724,13 +1723,13 @@ def add_optimizer_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "optdb__max_use_ratio",
         "A ratio that prevent infinite loop in EquilibriumOptimizer.",
         FloatParam(8),
         in_c_key=False,
     )
-    AddConfigVar(
+    config.add(
         "cycle_detection",
         "If cycle_detection is set to regular, most inplaces are allowed,"
         "but it is slower. If cycle_detection is set to faster, less inplaces"
@@ -1742,7 +1741,7 @@ def add_optimizer_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "check_stack_trace",
         "A flag for checking the stack trace during the optimization process. "
         "default (off): does not check the stack trace of any optimization "
@@ -1758,7 +1757,7 @@ def add_optimizer_configvars():
 
 
 def add_blas_configvars():
-    AddConfigVar(
+    config.add(
         "blas__ldflags",
         "lib[s] to include for [Fortran] level-3 blas implementation",
         StrParam(default_blas_ldflags),
@@ -1766,7 +1765,7 @@ def add_blas_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "blas__check_openmp",
         "Check for openmp library conflict.\nWARNING: Setting this to False leaves you open to wrong results in blas-related operations.",
         BoolParam(True),
@@ -1775,7 +1774,7 @@ def add_blas_configvars():
 
 
 def add_metaopt_configvars():
-    AddConfigVar(
+    config.add(
         "metaopt__verbose",
         "0 for silent, 1 for only warnings, 2 for full output with"
         "timings and selected implementation",
@@ -1783,14 +1782,14 @@ def add_metaopt_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "metaopt__optimizer_excluding",
         ("exclude optimizers with these tags. " "Separate tags with ':'."),
         StrParam(""),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "metaopt__optimizer_including",
         ("include optimizers with these tags. " "Separate tags with ':'."),
         StrParam(""),
@@ -1799,28 +1798,28 @@ def add_metaopt_configvars():
 
 
 def add_vm_configvars():
-    AddConfigVar(
+    config.add(
         "profile",
         "If VM should collect profile information",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profile_optimizer",
         "If VM should collect optimizer profile information",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "profile_memory",
         "If VM should collect memory profile information and print it",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "vm__lazy",
         "Useful only for the vm linkers. When lazy is None,"
         " auto detect if lazy evaluation is needed and use the appropriate"
@@ -1833,7 +1832,7 @@ def add_vm_configvars():
 
 def add_deprecated_configvars():
     # TODO: remove this?
-    AddConfigVar(
+    config.add(
         "cache_optimizations",
         "WARNING: work in progress, does not work yet. "
         "Specify if the optimization cache should be used. This cache will "
@@ -1845,7 +1844,7 @@ def add_deprecated_configvars():
     )
 
     # TODO: remove this?
-    AddConfigVar(
+    config.add(
         "unittests__rseed",
         "Seed to use for randomized unit tests. "
         "Special value 'random' means using a seed of None.",
@@ -1854,7 +1853,7 @@ def add_deprecated_configvars():
     )
 
     # TODO: remove?
-    AddConfigVar(
+    config.add(
         "warn__identify_1pexp_bug",
         "Warn if Theano versions prior to 7987b51 (2011-12-18) could have "
         "yielded a wrong result due to a bug in the is_1pexp function",
@@ -1862,7 +1861,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
     # TODO: this setting is not used anywhere
-    AddConfigVar(
+    config.add(
         "gpu__local_elemwise_fusion",
         (
             "Enable or not in fast_run mode(fast_run optimization) the gpu "
@@ -1872,14 +1871,14 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
     # TODO: this setting is not used anywhere
-    AddConfigVar(
+    config.add(
         "gpuelemwise__sync",
         "when true, wait that the gpu fct finished and check it error code.",
         BoolParam(True),
         in_c_key=False,
     )
     # TODO: most of these bugfix-related warnings can probably be removed
-    AddConfigVar(
+    config.add(
         "warn__argmax_pushdown_bug",
         (
             "Warn if in past version of Theano we generated a bug with the "
@@ -1890,7 +1889,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__gpusum_01_011_0111_bug",
         (
             "Warn if we are in a case where old version of Theano had a "
@@ -1901,7 +1900,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__sum_sum_bug",
         (
             "Warn if we are in a case where Theano version between version "
@@ -1914,7 +1913,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__sum_div_dimshuffle_bug",
         (
             "Warn if previous versions of Theano (between rev. "
@@ -1926,7 +1925,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__subtensor_merge_bug",
         "Warn if previous versions of Theano (before 0.5rc2) could have given "
         "incorrect results when indexing into a subtensor with negative "
@@ -1935,7 +1934,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__gpu_set_subtensor1",
         "Warn if previous versions of Theano (before 0.6) could have given "
         "incorrect results when moving to the gpu "
@@ -1944,7 +1943,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__vm_gc_bug",
         "There was a bug that existed in the default Theano configuration,"
         " only in the development version between July 5th 2012"
@@ -1957,7 +1956,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__signal_conv2d_interface",
         (
             "Warn we use the new signal.conv2d() when its interface"
@@ -1967,7 +1966,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__reduce_join",
         (
             "Your current code is fine, but Theano versions "
@@ -1984,7 +1983,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__inc_set_subtensor1",
         (
             "Warn if previous versions of Theano (before 0.7) could have "
@@ -1996,7 +1995,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__round",
         "Warn when using `tensor.round` with the default mode. "
         "Round changed its default from `half_away_from_zero` to "
@@ -2005,7 +2004,7 @@ def add_deprecated_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "warn__inc_subtensor1_opt",
         "Warn if previous versions of Theano (before 0.10) could have "
         "given incorrect results when computing "
@@ -2017,14 +2016,14 @@ def add_deprecated_configvars():
 
 
 def add_scan_configvars():
-    AddConfigVar(
+    config.add(
         "scan__allow_gc",
         "Allow/disallow gc inside of Scan (default: False)",
         BoolParam(False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "scan__allow_output_prealloc",
         "Allow/disallow memory preallocation for outputs inside of scan "
         "(default: True)",
@@ -2032,7 +2031,7 @@ def add_scan_configvars():
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "scan__debug",
         "If True, enable extra verbose output related to scan",
         BoolParam(False),
@@ -2062,7 +2061,7 @@ def add_caching_dir_configvars():
         "%(python_version)s-%(python_bitwidth)s"
     )
 
-    AddConfigVar(
+    config.add(
         "compiledir_format",
         textwrap.fill(
             textwrap.dedent(
@@ -2155,7 +2154,7 @@ def add_caching_dir_configvars():
     else:
         default_base_compiledir = os.path.join(get_home_dir(), ".theano")
 
-    AddConfigVar(
+    config.add(
         "base_compiledir",
         "platform-independent root directory for compiled modules",
         ConfigParam(
@@ -2167,14 +2166,14 @@ def add_caching_dir_configvars():
     def default_compiledir():
         return os.path.join(theano.config.base_compiledir, default_compiledirname())
 
-    AddConfigVar(
+    config.add(
         "compiledir",
         "platform-dependent cache directory for compiled modules",
         ConfigParam(default_compiledir, apply=filter_compiledir, mutable=False),
         in_c_key=False,
     )
 
-    AddConfigVar(
+    config.add(
         "gpuarray__cache_path",
         "Directory to cache pre-compiled kernels for the gpuarray backend.",
         ConfigParam(

--- a/theano/configdefaults.py
+++ b/theano/configdefaults.py
@@ -2232,10 +2232,15 @@ SUPPORTED_DNN_CONV_PRECISION = (
     "float64",
 )
 
-# TODO: we should add the configs explicitly to an instance of the TheanoConfigParser
-# Even if we treat it as a singleton, we should implement as if it wasn't, so we can
-# test it independently.
-config = theano.configparser.config
+# Eventually, the instance of `TheanoConfigParser` should be created right here,
+# where it is also populated with settings.  But for a transition period, it
+# remains as `configparser._config`, while everybody accessing it through
+# `configparser.config` is flooded with deprecation warnings. These warnings
+# instruct one to use `theano.config`, which is an alias for
+# `theano.configdefaults.config`.
+config = theano.configparser._config
+
+# The functions below register config variables into the config instance above.
 add_basic_configvars()
 add_dnn_configvars()
 add_magma_configvars()

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -1,4 +1,3 @@
-import configparser as ConfigParser
 import hashlib
 import logging
 import os
@@ -6,6 +5,13 @@ import shlex
 import sys
 import typing
 import warnings
+from configparser import (
+    ConfigParser,
+    InterpolationError,
+    NoOptionError,
+    NoSectionError,
+    RawConfigParser,
+)
 from functools import wraps
 from io import StringIO
 
@@ -195,9 +201,9 @@ class TheanoConfigParser:
         try:
             try:
                 return self._theano_cfg.get(section, option)
-            except ConfigParser.InterpolationError:
+            except InterpolationError:
                 return self._theano_raw_cfg.get(section, option)
-        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+        except (NoOptionError, NoSectionError):
             raise KeyError(key)
 
     def change_flags(self, *args, **kwargs) -> _ChangeFlagsDecorator:
@@ -494,7 +500,7 @@ def _create_default_config():
     THEANO_FLAGS_DICT = parse_config_string(THEANO_FLAGS, issue_warnings=True)
 
     config_files = config_files_from_theanorc()
-    theano_cfg = ConfigParser.ConfigParser(
+    theano_cfg = ConfigParser(
         {
             "USER": os.getenv("USER", os.path.split(os.path.expanduser("~"))[-1]),
             "LSCRATCH": os.getenv("LSCRATCH", ""),
@@ -508,7 +514,7 @@ def _create_default_config():
     # Having a raw version of the config around as well enables us to pass
     # through config values that contain format strings.
     # The time required to parse the config twice is negligible.
-    theano_raw_cfg = ConfigParser.RawConfigParser()
+    theano_raw_cfg = RawConfigParser()
     theano_raw_cfg.read(config_files)
 
     # Instances of TheanoConfigParser can have independent current values!

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -130,12 +130,12 @@ class TheanoConfigParser:
         """
         all_opts = sorted(
             [c for c in self._config_var_dict.values() if c.in_c_key],
-            key=lambda cv: cv.fullname,
+            key=lambda cv: cv.name,
         )
         return _hash_from_code(
             "\n".join(
                 [
-                    "{} = {}".format(cv.fullname, cv.__get__(self, self.__class__))
+                    "{} = {}".format(cv.name, cv.__get__(self, self.__class__))
                     for cv in all_opts
                 ]
             )
@@ -170,7 +170,7 @@ class TheanoConfigParser:
         if hasattr(self, name):
             raise AttributeError(f"The name {name} is already taken")
         configparam.doc = doc
-        configparam.fullname = name
+        configparam.name = name
         configparam.in_c_key = in_c_key
         # Trigger a read of the value from config files and env vars
         # This allow to filter wrong value from the user.
@@ -296,7 +296,7 @@ class ConfigParam:
         self._mutable = mutable
         self.is_default = True
         # set by TheanoConfigParser.add:
-        self.fullname = None
+        self.name = None
         self.doc = None
         self.in_c_key = None
 
@@ -336,7 +336,7 @@ class ConfigParam:
             return True
         if self._validate(value) is False:
             raise ValueError(
-                f"Invalid value ({value}) for configuration variable '{self.fullname}'."
+                f"Invalid value ({value}) for configuration variable '{self.name}'."
             )
         return True
 
@@ -345,7 +345,7 @@ class ConfigParam:
             return self
         if not hasattr(self, "val"):
             try:
-                val_str = cls.fetch_val_for_key(self.fullname, delete_key=delete_key)
+                val_str = cls.fetch_val_for_key(self.name, delete_key=delete_key)
                 self.is_default = False
             except KeyError:
                 if callable(self.default):
@@ -358,7 +358,7 @@ class ConfigParam:
     def __set__(self, cls, val):
         if not self.mutable and hasattr(self, "val"):
             raise Exception(
-                "Can't change the value of {self.fullname} config parameter after initialization!"
+                "Can't change the value of {self.name} config parameter after initialization!"
             )
         applied = self.apply(val)
         self.validate(applied)
@@ -396,18 +396,18 @@ class EnumStr(ConfigParam):
             return val
         else:
             raise ValueError(
-                f"Invalid value ('{val}') for configuration variable '{self.fullname}'. "
+                f"Invalid value ('{val}') for configuration variable '{self.name}'. "
                 f"Valid options are {self.all}"
             )
 
     def __str__(self):
-        return f"{self.fullname} ({self.all}) "
+        return f"{self.name} ({self.all}) "
 
 
 class TypedParam(ConfigParam):
     def __str__(self):
         # The "_apply" callable is the type itself.
-        return f"{self.fullname} ({self._apply}) "
+        return f"{self.name} ({self._apply}) "
 
 
 class StrParam(TypedParam):
@@ -440,7 +440,7 @@ class BoolParam(TypedParam):
         elif value in {True, 1, "true", "True", "1"}:
             return True
         raise ValueError(
-            f"Invalid value ({value}) for configuration variable '{self.fullname}'."
+            f"Invalid value ({value}) for configuration variable '{self.name}'."
         )
 
 
@@ -463,12 +463,12 @@ class DeviceParam(ConfigParam):
         else:
             raise ValueError(
                 'Invalid value ("{val}") for configuration '
-                'variable "{self.fullname}". Valid options start with '
+                'variable "{self.name}". Valid options start with '
                 'one of "cpu", "opencl" or "cuda".'
             )
 
     def __str__(self):
-        return f"{self.fullname} ({self.default}, opencl*, cuda*) "
+        return f"{self.name} ({self.default}, opencl*, cuda*) "
 
 
 class ContextsParam(ConfigParam):

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -23,10 +23,11 @@ class TheanoConfigWarning(Warning):
 class _ChangeFlagsDecorator:
     def __init__(self, *args, _root=None, **kwargs):
         # the old API supported passing a dict as the first argument:
-        args = dict(args)
-        args.update(kwargs)
-        self.confs = {k: _root._config_var_dict[k] for k in args}
-        self.new_vals = args
+        if args:
+            assert len(args) == 1 and isinstance(args[0], dict)
+            kwargs = dict(**args[0], **kwargs)
+        self.confs = {k: _root._config_var_dict[k] for k in kwargs}
+        self.new_vals = kwargs
         self._root = _root
 
     def __call__(self, f):

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -20,64 +20,12 @@ class TheanoConfigWarning(Warning):
     warn = classmethod(warn)
 
 
-def parse_config_string(config_string, issue_warnings=True):
-    """
-    Parses a config string (comma-separated key=value components) into a dict.
-    """
-    config_dict = {}
-    my_splitter = shlex.shlex(config_string, posix=True)
-    my_splitter.whitespace = ","
-    my_splitter.whitespace_split = True
-    for kv_pair in my_splitter:
-        kv_pair = kv_pair.strip()
-        if not kv_pair:
-            continue
-        kv_tuple = kv_pair.split("=", 1)
-        if len(kv_tuple) == 1:
-            if issue_warnings:
-                TheanoConfigWarning.warn(
-                    f"Config key '{kv_tuple[0]}' has no value, ignoring it",
-                    stacklevel=1,
-                )
-        else:
-            k, v = kv_tuple
-            # subsequent values for k will override earlier ones
-            config_dict[k] = v
-    return config_dict
-
-
-# THEANORC can contain a colon-delimited list of config files, like
-# THEANORC=~lisa/.theanorc:~/.theanorc
-# In that case, definitions in files on the right (here, ~/.theanorc) have
-# precedence over those in files on the left.
-def config_files_from_theanorc():
-    rval = [
-        os.path.expanduser(s)
-        for s in os.getenv("THEANORC", "~/.theanorc").split(os.pathsep)
-    ]
-    if os.getenv("THEANORC") is None and sys.platform == "win32":
-        # to don't need to change the filename and make it open easily
-        rval.append(os.path.expanduser("~/.theanorc.txt"))
-    return rval
-
-
-class change_flags:
-    """
-    Use this as a decorator or context manager to change the value of
-    Theano config variables.
-
-    Useful during tests.
-    """
-
-    def __init__(self, args=(), **kwargs):
-        confs = dict()
+class _ChangeFlagsDecorator:
+    def __init__(self, *args, _root=None, **kwargs):
+        # the old API supported passing a dict as the first argument:
         args = dict(args)
         args.update(kwargs)
-        for k in args:
-            l = [v for v in _config_var_list if v.fullname == k]
-            assert len(l) == 1, l
-            confs[k] = l[0]
-        self.confs = confs
+        self.confs = {k: _root._config_var_dict[k] for k in args}
         self.new_vals = args
 
     def __call__(self, f):
@@ -105,52 +53,6 @@ class change_flags:
             v.__set__(None, self.old_vals[k])
 
 
-def fetch_val_for_key(key, delete_key=False):
-    """Return the overriding config value for a key.
-    A successful search returns a string value.
-    An unsuccessful search raises a KeyError
-
-    The (decreasing) priority order is:
-    - THEANO_FLAGS
-    - ~./theanorc
-
-    """
-
-    # first try to find it in the FLAGS
-    if key in THEANO_FLAGS_DICT:
-        if delete_key:
-            return THEANO_FLAGS_DICT.pop(key)
-        return THEANO_FLAGS_DICT[key]
-
-    # next try to find it in the config file
-
-    # config file keys can be of form option, or section__option
-    key_tokens = key.rsplit("__", 1)
-    if len(key_tokens) > 2:
-        raise KeyError(key)
-
-    if len(key_tokens) == 2:
-        section, option = key_tokens
-    else:
-        section, option = "global", key
-    try:
-        try:
-            return theano_cfg.get(section, option)
-        except ConfigParser.InterpolationError:
-            return theano_raw_cfg.get(section, option)
-    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
-        raise KeyError(key)
-
-
-def _config_print(thing, buf, print_doc=True):
-    for cv in _config_var_list:
-        print(cv, file=buf)
-        if print_doc:
-            print("    Doc: ", cv.doc, file=buf)
-        print("    Value: ", cv.__get__(True, None), file=buf)
-        print("", file=buf)
-
-
 def _hash_from_code(msg):
     """This function was copied from theano.gof.utils to get rid of that import."""
     # hashlib.sha256() requires an object that supports buffer interface,
@@ -162,34 +64,148 @@ def _hash_from_code(msg):
     return "m" + hashlib.sha256(msg).hexdigest()
 
 
-def get_config_hash():
-    """
-    Return a string sha256 of the current config options. In the past,
-    it was md5.
-
-    The string should be such that we can safely assume that two different
-    config setups will lead to two different strings.
-
-    We only take into account config options for which `in_c_key` is True.
-    """
-    all_opts = sorted(
-        [c for c in _config_var_list if c.in_c_key], key=lambda cv: cv.fullname
-    )
-    return _hash_from_code(
-        "\n".join(
-            ["{} = {}".format(cv.fullname, cv.__get__(True, None)) for cv in all_opts]
-        )
-    )
-
-
 class TheanoConfigParser:
-    # properties are installed by AddConfigVar
-    _i_am_a_config_class = True
+    """ Object that holds configuration settings. """
+
+    def __init__(self, flags_dict: dict, theano_cfg, theano_raw_cfg):
+        self._flags_dict = flags_dict
+        self._theano_cfg = theano_cfg
+        self._theano_raw_cfg = theano_raw_cfg
+        self._config_var_dict = {}
+        super().__init__()
 
     def __str__(self, print_doc=True):
         sio = StringIO()
-        _config_print(self.__class__, sio, print_doc=print_doc)
+        self.config_print(buf=sio, print_doc=print_doc)
         return sio.getvalue()
+
+    def config_print(self, buf, print_doc=True):
+        for cv in self._config_var_dict.values():
+            print(cv, file=buf)
+            if print_doc:
+                print("    Doc: ", cv.doc, file=buf)
+            print("    Value: ", cv.__get__(True, None), file=buf)
+            print("", file=buf)
+
+    def get_config_hash(self):
+        """
+        Return a string sha256 of the current config options. In the past,
+        it was md5.
+
+        The string should be such that we can safely assume that two different
+        config setups will lead to two different strings.
+
+        We only take into account config options for which `in_c_key` is True.
+        """
+        all_opts = sorted(
+            [c for c in self._config_var_dict.values() if c.in_c_key],
+            key=lambda cv: cv.fullname,
+        )
+        return _hash_from_code(
+            "\n".join(
+                [
+                    "{} = {}".format(cv.fullname, cv.__get__(True, None))
+                    for cv in all_opts
+                ]
+            )
+        )
+
+    def add(self, name, doc, configparam, in_c_key=True):
+        """Add a new variable to TheanoConfigParser.
+
+        This method performs some of the work of initializing `ConfigParam` instances.
+
+        Parameters
+        ----------
+        name: string
+            The full name for this configuration variable. Takes the form
+            ``"[section0__[section1__[etc]]]_option"``.
+        doc: string
+            A string that provides documentation for the config variable.
+        configparam: ConfigParam
+            An object for getting and setting this configuration parameter
+        in_c_key: boolean
+            If ``True``, then whenever this config option changes, the key
+            associated to compiled C modules also changes, i.e. it may trigger a
+            compilation of these modules (this compilation will only be partial if it
+            turns out that the generated C code is unchanged). Set this option to False
+            only if you are confident this option should not affect C code compilation.
+
+        """
+        if "." in name:
+            raise ValueError(
+                f"Dot-based sections were removed. Use double underscores! ({name})"
+            )
+        if hasattr(self, name):
+            raise AttributeError(f"The name {name} is already taken")
+        configparam.doc = doc
+        configparam.fullname = name
+        configparam.in_c_key = in_c_key
+        # Trigger a read of the value from config files and env vars
+        # This allow to filter wrong value from the user.
+        if not callable(configparam.default):
+            configparam.__get__(self, type(self), delete_key=True)
+        else:
+            # We do not want to evaluate now the default value
+            # when it is a callable.
+            try:
+                self.fetch_val_for_key(name)
+                # The user provided a value, filter it now.
+                configparam.__get__(self, type(self), delete_key=True)
+            except KeyError:
+                _logger.error(
+                    f"Suppressed KeyError in AddConfigVar for parameter '{name}'!"
+                )
+
+        # the ConfigParam implements __get__/__set__, enabling us to create a property:
+        setattr(self.__class__, name, configparam)
+        # keep the ConfigParam object in a dictionary:
+        self._config_var_dict[name] = configparam
+
+    def fetch_val_for_key(self, key, delete_key=False):
+        """Return the overriding config value for a key.
+        A successful search returns a string value.
+        An unsuccessful search raises a KeyError
+
+        The (decreasing) priority order is:
+        - THEANO_FLAGS
+        - ~./theanorc
+
+        """
+
+        # first try to find it in the FLAGS
+        if key in self._flags_dict:
+            if delete_key:
+                return self._flags_dict.pop(key)
+            return self._flags_dict[key]
+
+        # next try to find it in the config file
+
+        # config file keys can be of form option, or section__option
+        key_tokens = key.rsplit("__", 1)
+        if len(key_tokens) > 2:
+            raise KeyError(key)
+
+        if len(key_tokens) == 2:
+            section, option = key_tokens
+        else:
+            section, option = "global", key
+        try:
+            try:
+                return self._theano_cfg.get(section, option)
+            except ConfigParser.InterpolationError:
+                return self._theano_raw_cfg.get(section, option)
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            raise KeyError(key)
+
+    def change_flags(self, *args, **kwargs) -> _ChangeFlagsDecorator:
+        """
+        Use this as a decorator or context manager to change the value of
+        Theano config variables.
+
+        Useful during tests.
+        """
+        return _ChangeFlagsDecorator(*args, _root=self, **kwargs)
 
 
 class ConfigParam:
@@ -198,6 +214,9 @@ class ConfigParam:
     A ConfigParam has not only default values and configurable mutability, but
     also documentation text, as well as filtering and validation routines
     that can be context-dependent.
+
+    This class implements __get__ and __set__ methods to eventually become
+    a property on an instance of TheanoConfigParser.
     """
 
     def __init__(
@@ -230,9 +249,10 @@ class ConfigParam:
         self._validate = validate
         self._mutable = mutable
         self.is_default = True
-        # set by AddConfigVar:
+        # set by TheanoConfigParser.add:
         self.fullname = None
         self.doc = None
+        self.in_c_key = None
 
         # Note that we do not call `self.filter` on the default value: this
         # will be done automatically in AddConfigVar, potentially with a
@@ -279,7 +299,7 @@ class ConfigParam:
             return self
         if not hasattr(self, "val"):
             try:
-                val_str = fetch_val_for_key(self.fullname, delete_key=delete_key)
+                val_str = cls.fetch_val_for_key(self.fullname, delete_key=delete_key)
                 self.is_default = False
             except KeyError:
                 if callable(self.default):
@@ -421,103 +441,86 @@ class ContextsParam(ConfigParam):
         return val
 
 
-# TODO: Not all of the following variables need to exist. Most should be private.
-THEANO_FLAGS = os.getenv("THEANO_FLAGS", "")
-# The THEANO_FLAGS environment variable should be a list of comma-separated
-# [section__]option=value entries. If the section part is omitted, there should
-# be only one section that contains the given option.
-THEANO_FLAGS_DICT = parse_config_string(THEANO_FLAGS, issue_warnings=True)
-_config_var_list = []
-
-config_files = config_files_from_theanorc()
-theano_cfg = ConfigParser.ConfigParser(
-    {
-        "USER": os.getenv("USER", os.path.split(os.path.expanduser("~"))[-1]),
-        "LSCRATCH": os.getenv("LSCRATCH", ""),
-        "TMPDIR": os.getenv("TMPDIR", ""),
-        "TEMP": os.getenv("TEMP", ""),
-        "TMP": os.getenv("TMP", ""),
-        "PID": str(os.getpid()),
-    }
-)
-theano_cfg.read(config_files)
-# Having a raw version of the config around as well enables us to pass
-# through config values that contain format strings.
-# The time required to parse the config twice is negligible.
-theano_raw_cfg = ConfigParser.RawConfigParser()
-theano_raw_cfg.read(config_files)
-
-# N.B. all instances of TheanoConfigParser give access to the same properties.
-config = TheanoConfigParser()
-
-
-def AddConfigVar(name, doc, configparam, root=config, in_c_key=True):
-    """Add a new variable to `theano.config`.
-
-    The data structure at work here is a tree of classes with class
-    attributes/properties that are either a) instantiated dynamically-generated
-    classes, or b) `ConfigParam` instances.  The root of this tree is the
-    `TheanoConfigParser` class, and the internal nodes are the ``SubObj``
-    classes created inside of `AddConfigVar`.
-
-    Why this design?
-    - The config object is a true singleton.  Every instance of
-    `TheanoConfigParser` is an empty instance that looks up
-    attributes/properties in the [single] ``TheanoConfigParser.__dict__``
-    - The subtrees provide the same interface as the root
-    - `ConfigParser` subclasses control get/set of config properties to guard
-    against craziness.
-
-    This method also performs some of the work of initializing `ConfigParam`
-    instances
-
-    Parameters
-    ----------
-    name: string
-        The full name for this configuration variable. Takes the form
-        ``"[section0__[section1__[etc]]]_option"``.
-    doc: string
-        A string that provides documentation for the config variable.
-    configparam: ConfigParam
-        An object for getting and setting this configuration parameter
-    root: object
-        Used for recursive calls.  Do not provide a value for this parameter.
-    in_c_key: boolean
-        If ``True``, then whenever this config option changes, the key
-        associated to compiled C modules also changes, i.e. it may trigger a
-        compilation of these modules (this compilation will only be partial if it
-        turns out that the generated C code is unchanged). Set this option to False
-        only if you are confident this option should not affect C code compilation.
-
+def parse_config_string(config_string, issue_warnings=True):
     """
+    Parses a config string (comma-separated key=value components) into a dict.
+    """
+    config_dict = {}
+    my_splitter = shlex.shlex(config_string, posix=True)
+    my_splitter.whitespace = ","
+    my_splitter.whitespace_split = True
+    for kv_pair in my_splitter:
+        kv_pair = kv_pair.strip()
+        if not kv_pair:
+            continue
+        kv_tuple = kv_pair.split("=", 1)
+        if len(kv_tuple) == 1:
+            if issue_warnings:
+                TheanoConfigWarning.warn(
+                    f"Config key '{kv_tuple[0]}' has no value, ignoring it",
+                    stacklevel=1,
+                )
+        else:
+            k, v = kv_tuple
+            # subsequent values for k will override earlier ones
+            config_dict[k] = v
+    return config_dict
 
-    if root is config:
-        # Only set the name in the first call, not the recursive ones
-        configparam.fullname = name
-    if "." in name:
-        raise ValueError(
-            f"Dot-based sections were removed. Use double underscores! ({name})"
-        )
-    if hasattr(root, name):
-        raise AttributeError(f"The name {configparam.fullname} is already taken")
-    configparam.doc = doc
-    configparam.in_c_key = in_c_key
-    # Trigger a read of the value from config files and env vars
-    # This allow to filter wrong value from the user.
-    if not callable(configparam.default):
-        configparam.__get__(root, type(root), delete_key=True)
-    else:
-        # We do not want to evaluate now the default value
-        # when it is a callable.
-        try:
-            fetch_val_for_key(configparam.fullname)
-            # The user provided a value, filter it now.
-            configparam.__get__(root, type(root), delete_key=True)
-        except KeyError:
-            _logger.error(
-                f"Suppressed KeyError in AddConfigVar for parameter '{name}' with fullname '{configparam.fullname}'!"
-            )
-    setattr(root.__class__, name, configparam)
-    # TODO: After assigning the configvar to the "root" object, there should be
-    # no reason to keep the _config_var_list around!
-    _config_var_list.append(configparam)
+
+def config_files_from_theanorc():
+    """
+    THEANORC can contain a colon-delimited list of config files, like
+    THEANORC=~lisa/.theanorc:~/.theanorc
+    In that case, definitions in files on the right (here, ~/.theanorc) have
+    precedence over those in files on the left.
+    """
+    rval = [
+        os.path.expanduser(s)
+        for s in os.getenv("THEANORC", "~/.theanorc").split(os.pathsep)
+    ]
+    if os.getenv("THEANORC") is None and sys.platform == "win32":
+        # to don't need to change the filename and make it open easily
+        rval.append(os.path.expanduser("~/.theanorc.txt"))
+    return rval
+
+
+def _create_default_config():
+    # The THEANO_FLAGS environment variable should be a list of comma-separated
+    # [section__]option=value entries. If the section part is omitted, there should
+    # be only one section that contains the given option.
+    THEANO_FLAGS = os.getenv("THEANO_FLAGS", "")
+    THEANO_FLAGS_DICT = parse_config_string(THEANO_FLAGS, issue_warnings=True)
+
+    config_files = config_files_from_theanorc()
+    theano_cfg = ConfigParser.ConfigParser(
+        {
+            "USER": os.getenv("USER", os.path.split(os.path.expanduser("~"))[-1]),
+            "LSCRATCH": os.getenv("LSCRATCH", ""),
+            "TMPDIR": os.getenv("TMPDIR", ""),
+            "TEMP": os.getenv("TEMP", ""),
+            "TMP": os.getenv("TMP", ""),
+            "PID": str(os.getpid()),
+        }
+    )
+    theano_cfg.read(config_files)
+    # Having a raw version of the config around as well enables us to pass
+    # through config values that contain format strings.
+    # The time required to parse the config twice is negligible.
+    theano_raw_cfg = ConfigParser.RawConfigParser()
+    theano_raw_cfg.read(config_files)
+
+    # Instances of TheanoConfigParser can have independent current values!
+    # But because the properties are assinged to the type, their existence is global.
+    config = TheanoConfigParser(
+        flags_dict=THEANO_FLAGS_DICT,
+        theano_cfg=theano_cfg,
+        theano_raw_cfg=theano_raw_cfg,
+    )
+    return config
+
+
+config = _create_default_config()
+# aliasing for old API
+AddConfigVar = config.add
+change_flags = config.change_flags
+_config_print = config.config_print

--- a/theano/configparser.py
+++ b/theano/configparser.py
@@ -565,14 +565,17 @@ def _create_default_config():
     return config
 
 
-# will be overwritten by configdefaults
-class ConfigProxy:
+class _ConfigProxy:
+    """Like _SectionRedirect this class enables backwards-compatible access to the
+    config settings, but raises DeprecationWarnings with instructions to use `theano.config`.
+    """
+
     def __init__(self, actual):
-        ConfigProxy._actual = actual
+        _ConfigProxy._actual = actual
 
     def __getattr__(self, attr):
         if attr == "_actual":
-            return ConfigProxy._actual
+            return _ConfigProxy._actual
         warnings.warn(
             "Accessing config through `theano.configparser.config` is deprecated. "
             "Use `theano.config` instead.",
@@ -583,7 +586,7 @@ class ConfigProxy:
 
     def __setattr__(self, attr, value):
         if attr == "_actual":
-            return setattr(ConfigProxy._actual, attr, value)
+            return setattr(_ConfigProxy._actual, attr, value)
         warnings.warn(
             "Accessing config through `theano.configparser.config` is deprecated. "
             "Use `theano.config` instead.",
@@ -600,7 +603,7 @@ _config = _create_default_config()
 # The old API often imported the default config object from `configparser`.
 # These imports/accesses should be replaced with `theano.config`, so this wraps
 # it with warnings:
-config = ConfigProxy(_config)
+config = _ConfigProxy(_config)
 # We can't alias the methods of the `config` variable above without already
 # triggering the warning.  Instead, we wrap the methods of the actual instance
 # with warnings:

--- a/theano/gof/cc.py
+++ b/theano/gof/cc.py
@@ -11,7 +11,6 @@ from io import StringIO
 
 import numpy as np
 
-import theano
 from theano import config
 from theano.gof import cmodule, graph, link, utils
 from theano.gof.callcache import CallCache
@@ -1472,7 +1471,7 @@ class CLinker(link.Linker):
         # NOTE: config md5 is not using md5 hash, but sha256 instead. Function
         # string instances of md5 will be updated at a later release.
         if insert_config_hash:
-            sig.append("md5:" + theano.configparser.get_config_hash())
+            sig.append("md5:" + config.get_config_hash())
         else:
             sig.append("md5: <omitted>")
 

--- a/theano/gof/type.py
+++ b/theano/gof/type.py
@@ -11,7 +11,7 @@ import platform
 import re
 
 import theano
-from theano import change_flags
+from theano import config
 from theano.gof import graph, utils
 
 ########
@@ -726,7 +726,7 @@ class CDataType(Type):
         from theano.scalar import get_scalar_type
 
         if self._fn is None:
-            with change_flags(compute_test_value="off"):
+            with config.change_flags(compute_test_value="off"):
                 v = get_scalar_type("int64")()
                 self._fn = theano.function(
                     [v],

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -13,7 +13,7 @@ import warnings
 from collections import defaultdict
 
 import theano.gof.cmodule
-from theano.configparser import _config_var_list, config
+from theano.configparser import config
 
 from . import link
 
@@ -715,9 +715,7 @@ except (OSError, theano.gof.cmodule.MissingGXX) as e:
     # already changed the default linker to something else then CVM.
     # Currently this is the py linker.
     # Here we assert that the default linker is not cvm.
-    assert not [x for x in _config_var_list if x.fullname == "linker"][
-        0
-    ].default.startswith("cvm"), e
+    assert not config._config_var_dict["linker"].default.startswith("cvm"), e
 
 
 class VM_Linker(link.LocalLinker):

--- a/theano/gof/vm.py
+++ b/theano/gof/vm.py
@@ -13,7 +13,7 @@ import warnings
 from collections import defaultdict
 
 import theano.gof.cmodule
-from theano.configparser import config
+from theano import config
 
 from . import link
 

--- a/theano/sandbox/rng_mrg.py
+++ b/theano/sandbox/rng_mrg.py
@@ -798,7 +798,7 @@ class MRG_RandomStreams:
         self.rstate = multMatVect(self.rstate, A1p134, M1, A2p134, M2)
         assert self.rstate.dtype == np.int32
 
-    @theano.change_flags(compute_test_value="off")
+    @config.change_flags(compute_test_value="off")
     def get_substream_rstates(self, n_streams, dtype, inc_rstate=True):
         # TODO : need description for parameter and return
         """

--- a/theano/scalar/basic.py
+++ b/theano/scalar/basic.py
@@ -346,7 +346,7 @@ class Scalar(Type):
                 or (
                     allow_downcast is None
                     and isinstance(data, (float, np.floating))
-                    and self.dtype == theano.config.floatX
+                    and self.dtype == config.floatX
                 )
                 or data == converted_data
             ):
@@ -1204,7 +1204,7 @@ class ScalarOp(Op):
                     tmp_s_input.append(tmp)
                     mapping[ii] = tmp_s_input[-1]
 
-            with theano.change_flags(compute_test_value="ignore"):
+            with config.change_flags(compute_test_value="ignore"):
                 s_op = self(*tmp_s_input, return_list=True)
 
             # if the scalar_op don't have a c implementation,
@@ -1231,7 +1231,7 @@ class UnaryScalarOp(ScalarOp):
         (x,) = inputs
         (z,) = outputs
         if (
-            not theano.config.lib__amblibm
+            not config.lib__amblibm
             or
             # We compare the dtype AND the broadcast flag
             # as this function do not broadcast
@@ -1303,8 +1303,8 @@ class LogicalComparison(BinaryScalarOp):
         x, y = inputs
         assert outputs[0].type == bool
         return [
-            x.zeros_like().astype(theano.config.floatX),
-            y.zeros_like().astype(theano.config.floatX),
+            x.zeros_like().astype(config.floatX),
+            y.zeros_like().astype(config.floatX),
         ]
 
     def c_code_cache_version(self):
@@ -1338,7 +1338,7 @@ class FixedLogicalComparison(UnaryScalarOp):
     def L_op(self, inputs, outputs, output_gradients):
         (x,) = inputs
         assert outputs[0].type == bool
-        return [x.zeros_like().astype(theano.config.floatX)]
+        return [x.zeros_like().astype(config.floatX)]
 
     def c_code_cache_version(self):
         super_version = super().c_code_cache_version()
@@ -1557,7 +1557,7 @@ class InRange(LogicalComparison):
             )
             raise NotImplementedError(msg)
         elif elem.type in discrete_types:
-            return elem.zeros_like().astype(theano.config.floatX)
+            return elem.zeros_like().astype(config.floatX)
         else:
             return elem.zeros_like()
 
@@ -1599,7 +1599,7 @@ class Switch(ScalarOp):
         # cond does affect the elements of the output so it is connected.
         # For the sake of making the gradient convenient we assume that
         # condition + epsilon always triggers the same branch as condition
-        condition_grad = cond.zeros_like().astype(theano.config.floatX)
+        condition_grad = cond.zeros_like().astype(config.floatX)
 
         return (condition_grad, first_part, second_part)
 
@@ -1626,7 +1626,7 @@ class UnaryBitOp(UnaryScalarOp):
         return upcast_out(*input_types[0])
 
     def grad(self, inputs, output_gradients):
-        return [inputs[0].zeros_like().astype(theano.config.floatX)]
+        return [inputs[0].zeros_like().astype(config.floatX)]
 
 
 class BinaryBitOp(BinaryScalarOp):
@@ -1646,8 +1646,8 @@ class BinaryBitOp(BinaryScalarOp):
     def grad(self, inputs, output_gradients):
         a, b = inputs
         return [
-            a.zeros_like().astype(theano.config.floatX),
-            b.zeros_like().astype(theano.config.floatX),
+            a.zeros_like().astype(config.floatX),
+            b.zeros_like().astype(config.floatX),
         ]
 
 
@@ -1757,8 +1757,8 @@ class Maximum(BinaryScalarOp):
 
         if outputs[0].type in discrete_types:
             return [
-                x.zeros_like().astype(theano.config.floatX),
-                y.zeros_like().astype(theano.config.floatX),
+                x.zeros_like().astype(config.floatX),
+                y.zeros_like().astype(config.floatX),
             ]
         # This form handle the case when both value are the same.
         # In that case, gx will be gz, gy will be 0.
@@ -1798,8 +1798,8 @@ class Minimum(BinaryScalarOp):
 
         if outputs[0].type in discrete_types:
             return [
-                x.zeros_like().astype(theano.config.floatX),
-                y.zeros_like().astype(theano.config.floatX),
+                x.zeros_like().astype(config.floatX),
+                y.zeros_like().astype(config.floatX),
             ]
         # This form handle the case when both value are the same.
         # In that case, gx will be gz, gy will be 0.
@@ -1841,7 +1841,7 @@ class Add(ScalarOp):
             retval = []
             for ii, inp in enumerate(inputs):
                 if hasattr(inp, "zeros_like"):
-                    retval.append(inp.zeros_like().astype(theano.config.floatX))
+                    retval.append(inp.zeros_like().astype(config.floatX))
                 else:
                     retval.append(grad_undefined(self, ii, inp))
         else:
@@ -1891,7 +1891,7 @@ class Mul(ScalarOp):
                 )
 
         if output_type in discrete_types:
-            return [ipt.zeros_like().astype(theano.config.floatX) for ipt in inputs]
+            return [ipt.zeros_like().astype(config.floatX) for ipt in inputs]
 
         for input in inputs:
             if gz.type in complex_types:
@@ -1934,8 +1934,8 @@ class Sub(BinaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             return [
-                x.zeros_like().astype(theano.config.floatX),
-                y.zeros_like().astype(theano.config.floatX),
+                x.zeros_like().astype(config.floatX),
+                y.zeros_like().astype(config.floatX),
             ]
 
         first_part = gz
@@ -2170,7 +2170,7 @@ class IntDiv(BinaryScalarOp):
         return (6,)
 
     def grad(self, inputs, g_output):
-        return [inp.zeros_like(dtype=theano.config.floatX) for inp in inputs]
+        return [inp.zeros_like(dtype=config.floatX) for inp in inputs]
 
 
 int_div = IntDiv(upcast_out, name="int_div")
@@ -2291,8 +2291,8 @@ class Mod(BinaryScalarOp):
         if outputs[0].type.dtype in discrete_types:
             # The gradient does not flow in if the output is discrete
             return [
-                x.zeros_like(dtype=theano.config.floatX),
-                y.zeros_like(dtype=theano.config.floatX),
+                x.zeros_like(dtype=config.floatX),
+                y.zeros_like(dtype=config.floatX),
             ]
         return [gz, -(x // y) * gz]
 
@@ -2321,8 +2321,8 @@ class Pow(BinaryScalarOp):
 
         if outputs[0].type in discrete_types:
             return [
-                x.zeros_like().astype(theano.config.floatX),
-                y.zeros_like().astype(theano.config.floatX),
+                x.zeros_like().astype(config.floatX),
+                y.zeros_like().astype(config.floatX),
             ]
 
         first_part = gz * y * x ** (y - 1)
@@ -2335,7 +2335,7 @@ class Pow(BinaryScalarOp):
     def c_code_contiguous(self, node, name, inputs, outputs, sub):
         (x, y) = inputs
         (z,) = outputs
-        if not theano.config.lib__amblibm:
+        if not config.lib__amblibm:
             raise theano.gof.utils.MethodNotDefined()
 
         # We compare the dtype AND the broadcast flag
@@ -2471,7 +2471,7 @@ class Identity(UnaryScalarOp):
         if x.type in continuous_types:
             return (gz,)
         else:
-            return (x.zeros_like(dtype=theano.config.floatX),)
+            return (x.zeros_like(dtype=config.floatX),)
 
 
 identity = Identity(same_out, name="identity")
@@ -2522,7 +2522,7 @@ class Cast(UnaryScalarOp):
         if self.o_type in continuous_types:
             return [gz]
         else:
-            return [x.zeros_like().astype(theano.config.floatX)]
+            return [x.zeros_like().astype(config.floatX)]
 
     def c_code_cache_version(self):
         s = super().c_code_cache_version()
@@ -2605,7 +2605,7 @@ class Abs(UnaryScalarOp):
         (gz,) = gout
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -2653,7 +2653,7 @@ class Sgn(UnaryScalarOp):
         rval = x.zeros_like()
 
         if rval.type.dtype in discrete_types:
-            rval = rval.astype(theano.config.floatX)
+            rval = rval.astype(config.floatX)
 
         return [rval]
 
@@ -2694,7 +2694,7 @@ class Ceil(UnaryScalarOp):
         rval = x.zeros_like()
 
         if rval.type.dtype in discrete_types:
-            rval = rval.astype(theano.config.floatX)
+            rval = rval.astype(config.floatX)
 
         return [rval]
 
@@ -2720,7 +2720,7 @@ class Floor(UnaryScalarOp):
         rval = x.zeros_like()
 
         if rval.type.dtype in discrete_types:
-            rval = rval.astype(theano.config.floatX)
+            rval = rval.astype(config.floatX)
 
         return [rval]
 
@@ -2743,7 +2743,7 @@ class Trunc(UnaryScalarOp):
     def grad(self, inputs, gout):
         (x,) = inputs
         (gz,) = gout
-        return [x.zeros_like().astype(theano.config.floatX)]
+        return [x.zeros_like().astype(config.floatX)]
 
     def c_code(self, node, name, inputs, outputs, sub):
         (x,) = inputs
@@ -2774,7 +2774,7 @@ class RoundHalfToEven(UnaryScalarOp):
         rval = x.zeros_like()
 
         if rval.type.dtype in discrete_types:
-            rval = rval.astype(theano.config.floatX)
+            rval = rval.astype(config.floatX)
 
         return [rval]
 
@@ -2860,7 +2860,7 @@ class RoundHalfAwayFromZero(UnaryScalarOp):
         rval = x.zeros_like()
 
         if rval.type.dtype in discrete_types:
-            rval = rval.astype(theano.config.floatX)
+            rval = rval.astype(config.floatX)
 
         return [rval]
 
@@ -2890,7 +2890,7 @@ class Neg(UnaryScalarOp):
         (gz,) = gout
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -2932,7 +2932,7 @@ class Inv(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -2974,7 +2974,7 @@ class Log(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3020,7 +3020,7 @@ class Log2(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3063,7 +3063,7 @@ class Log10(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3104,7 +3104,7 @@ class Log1p(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3142,7 +3142,7 @@ class Exp(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3178,7 +3178,7 @@ class Exp2(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3214,7 +3214,7 @@ class Expm1(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3248,7 +3248,7 @@ class Sqr(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3281,7 +3281,7 @@ class Sqrt(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3317,7 +3317,7 @@ class Deg2Rad(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3352,7 +3352,7 @@ class Rad2Deg(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3389,7 +3389,7 @@ class Cos(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3425,7 +3425,7 @@ class ArcCos(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3463,7 +3463,7 @@ class Sin(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3499,7 +3499,7 @@ class ArcSin(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3535,7 +3535,7 @@ class Tan(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3571,7 +3571,7 @@ class ArcTan(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3610,11 +3610,11 @@ class ArcTan2(BinaryScalarOp):
         else:
             if outputs[0].type in discrete_types:
                 if x.type in discrete_types:
-                    gx = x.zeros_like(dtype=theano.config.floatX)
+                    gx = x.zeros_like(dtype=config.floatX)
                 else:
                     gx = x.zeros_like()
                 if y.type in discrete_types:
-                    gy = y.zeros_like(dtype=theano.config.floatX)
+                    gy = y.zeros_like(dtype=config.floatX)
                 else:
                     gy = y.zeros_like()
                 return [gx, gy]
@@ -3658,7 +3658,7 @@ class Cosh(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3694,7 +3694,7 @@ class ArcCosh(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3735,7 +3735,7 @@ class Sinh(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3771,7 +3771,7 @@ class ArcSinh(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3813,7 +3813,7 @@ class Tanh(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3849,7 +3849,7 @@ class ArcTanh(UnaryScalarOp):
             raise NotImplementedError()
         if outputs[0].type in discrete_types:
             if x.type in discrete_types:
-                return [x.zeros_like(dtype=theano.config.floatX)]
+                return [x.zeros_like(dtype=config.floatX)]
             else:
                 return [x.zeros_like()]
 
@@ -3902,7 +3902,7 @@ class Imag(UnaryScalarOp):
         elif x.type in float_types:
             return [second(x, 0)]
         else:
-            return [x.zeros_like(dtype=theano.config.floatX)]
+            return [x.zeros_like(dtype=config.floatX)]
 
 
 imag = Imag(real_out, name="imag")
@@ -3939,7 +3939,7 @@ class Angle(UnaryScalarOp):
         elif c in float_types:
             return [cast(second(x, 0), x.type.dtype)]
         else:
-            return [c.zeros_like(dtype=theano.config.floatX)]
+            return [c.zeros_like(dtype=config.floatX)]
 
 
 angle = Angle(specific_out(float64), name="angle")

--- a/theano/tensor/basic.py
+++ b/theano/tensor/basic.py
@@ -1179,7 +1179,7 @@ class TensorFromScalar(Op):
         # Currently, theano.grad insists that the dtype of the returned
         # gradient has a float dtype, so we use floatX.
         if s.type.dtype in discrete_dtypes:
-            return [s.zeros_like().astype(theano.config.floatX)]
+            return [s.zeros_like().astype(config.floatX)]
 
         raise NotImplementedError("grad not implemented for complex dtypes")
 
@@ -5655,7 +5655,7 @@ class ARange(Op):
 
         return Apply(self, inputs, outputs)
 
-    @theano.configparser.change_flags(warn_float64="ignore")
+    @config.change_flags(warn_float64="ignore")
     def infer_shape(self, fgraph, node, i_shapes):
         # Note start, stop and step can be float numbers.
         start, stop, step = node.inputs

--- a/theano/tensor/elemwise.py
+++ b/theano/tensor/elemwise.py
@@ -3,7 +3,7 @@ from copy import copy
 import numpy as np
 
 import theano
-from theano import change_flags, gof, scalar
+from theano import config, gof, scalar
 from theano.gof import Apply, COp, Op, OpenMPOp, ParamsType
 from theano.gof.null_type import NullType
 from theano.gradient import DisconnectedType
@@ -11,9 +11,6 @@ from theano.misc.frozendict import frozendict
 from theano.printing import pprint
 from theano.scalar import get_scalar_type
 from theano.tensor import elemwise_cgen as cgen
-
-
-config = theano.config
 
 
 _numpy_ver = [int(n) for n in np.__version__.split(".")[:2]]
@@ -308,7 +305,7 @@ class DimShuffle(COp):
         # canonicalization optimization phase will remove the inplace.
         # The inplace will be reintroduced automatically later in the graph.
         if inp[0].dtype in theano.tensor.discrete_dtypes:
-            return [inp[0].zeros_like(dtype=theano.config.floatX)]
+            return [inp[0].zeros_like(dtype=config.floatX)]
         else:
             return [
                 DimShuffle(gz.type.broadcastable, grad_order)(
@@ -591,7 +588,7 @@ second dimension
                 else:
                     elem = ipt.zeros_like()
                     if str(elem.type.dtype) not in theano.tensor.continuous_dtypes:
-                        elem = elem.astype(theano.config.floatX)
+                        elem = elem.astype(config.floatX)
                     assert str(elem.type.dtype) not in theano.tensor.discrete_dtypes
                     new_rval.append(elem)
             return new_rval
@@ -621,7 +618,7 @@ second dimension
     def _bgrad(self, inputs, outputs, ograds):
         # returns grad, with respect to broadcasted versions of inputs
 
-        with change_flags(compute_test_value="off"):
+        with config.change_flags(compute_test_value="off"):
 
             def as_scalar(t):
                 if isinstance(t.type, (NullType, DisconnectedType)):
@@ -1756,7 +1753,7 @@ class All(CAReduce):
 
     def grad(self, inp, grads):
         (x,) = inp
-        return [x.zeros_like(theano.config.floatX)]
+        return [x.zeros_like(config.floatX)]
 
 
 class Any(CAReduce):
@@ -1789,7 +1786,7 @@ class Any(CAReduce):
 
     def grad(self, inp, grads):
         (x,) = inp
-        return [x.zeros_like(theano.config.floatX)]
+        return [x.zeros_like(config.floatX)]
 
 
 class CAReduceDtype(CAReduce):
@@ -2019,7 +2016,7 @@ class Sum(CAReduceDtype):
         (x,) = inp
 
         if out[0].dtype not in theano.tensor.continuous_dtypes:
-            return [x.zeros_like(dtype=theano.config.floatX)]
+            return [x.zeros_like(dtype=config.floatX)]
 
         (gz,) = grads
         gz = as_tensor_variable(gz)
@@ -2127,7 +2124,7 @@ class Prod(CAReduceDtype):
             or self.acc_dtype in theano.tensor.discrete_dtypes
         ):
             # There is an int conversion in the way
-            return [prod_in.zeros_like(dtype=theano.config.floatX)]
+            return [prod_in.zeros_like(dtype=config.floatX)]
 
         # Prepare the broadcasting that is used everywhere to broadcast
         # over the original groups (ie. broadcast over the elements of a given

--- a/theano/tensor/nnet/bn.py
+++ b/theano/tensor/nnet/bn.py
@@ -17,7 +17,7 @@ from theano.tensor.type import TensorType
 class BNComposite(Composite):
     init_param = ("dtype",)
 
-    @theano.change_flags(compute_test_value="off")
+    @theano.config.change_flags(compute_test_value="off")
     def __init__(self, dtype):
         self.dtype = dtype
         x = theano.scalar.Scalar(dtype=dtype).make_variable()

--- a/theano/tensor/subtensor.py
+++ b/theano/tensor/subtensor.py
@@ -722,7 +722,7 @@ class Subtensor(Op):
         x = inputs[0]
         rest = inputs[1:]
         if x.dtype in theano.tensor.discrete_dtypes:
-            first = x.zeros_like().astype(theano.config.floatX)
+            first = x.zeros_like().astype(config.floatX)
         else:
             # For best optimization, we let this as an inc.
             # This allow the opt local_IncSubtensor_serialize to apply first.
@@ -1797,9 +1797,9 @@ class IncSubtensor(Op):
 
         if x.dtype in theano.tensor.discrete_dtypes:
             # The output dtype is the same as x
-            gx = x.zeros_like(dtype=theano.config.floatX)
+            gx = x.zeros_like(dtype=config.floatX)
             if y.dtype in theano.tensor.discrete_dtypes:
-                gy = y.zeros_like(dtype=theano.config.floatX)
+                gy = y.zeros_like(dtype=config.floatX)
             else:
                 gy = y.zeros_like()
         elif x.dtype in theano.tensor.complex_dtypes:
@@ -1933,7 +1933,7 @@ class AdvancedSubtensor1(Op):
         else:
             if x.dtype in theano.tensor.discrete_dtypes:
                 # The output dtype is the same as x
-                gx = x.zeros_like(dtype=theano.config.floatX)
+                gx = x.zeros_like(dtype=config.floatX)
             elif x.dtype in theano.tensor.complex_dtypes:
                 raise NotImplementedError("No support for complex grad yet")
             else:
@@ -2221,9 +2221,9 @@ class AdvancedIncSubtensor1(Op):
         x, y, idx_list = inputs
         if x.dtype in theano.tensor.discrete_dtypes:
             # The output dtype is the same as x
-            gx = x.zeros_like(dtype=theano.config.floatX)
+            gx = x.zeros_like(dtype=config.floatX)
             if y.dtype in theano.tensor.discrete_dtypes:
-                gy = y.zeros_like(dtype=theano.config.floatX)
+                gy = y.zeros_like(dtype=config.floatX)
             else:
                 gy = y.zeros_like()
         elif x.dtype in theano.tensor.complex_dtypes:
@@ -2298,7 +2298,7 @@ class AdvancedSubtensor(Op):
         # `Subtensor` calls, so we create a fake symbolic shape tuple and
         # identify the broadcast dimensions from the shape result of this
         # entire subtensor operation.
-        with theano.change_flags(compute_test_value="off"):
+        with config.change_flags(compute_test_value="off"):
             fake_shape = tuple(
                 theano.tensor.tensor(dtype="int64", broadcastable=())
                 if not bcast
@@ -2380,7 +2380,7 @@ class AdvancedSubtensor(Op):
         x = inputs[0]
         if x.dtype in theano.tensor.discrete_dtypes:
             # The output dtype is the same as x
-            gx = x.zeros_like(dtype=theano.config.floatX)
+            gx = x.zeros_like(dtype=config.floatX)
         elif x.dtype in theano.tensor.complex_dtypes:
             raise NotImplementedError("No support for complex grad yet")
         else:
@@ -2474,9 +2474,9 @@ class AdvancedIncSubtensor(Op):
         (outgrad,) = output_gradients
         if x.dtype in theano.tensor.discrete_dtypes:
             # The output dtype is the same as x
-            gx = x.zeros_like(dtype=theano.config.floatX)
+            gx = x.zeros_like(dtype=config.floatX)
             if y.dtype in theano.tensor.discrete_dtypes:
-                gy = y.zeros_like(dtype=theano.config.floatX)
+                gy = y.zeros_like(dtype=config.floatX)
             else:
                 gy = y.zeros_like()
         elif x.dtype in theano.tensor.complex_dtypes:


### PR DESCRIPTION
In both `configparser.py` and `configdefaults.py` several module-level variables were created and in some cases also used from other parts of the codebase.
These module-level globals are not good practice and stand in the way of creating an orthogonal instance of the `TheanoConfigParser` for testing.

While doing this PR I finally understood what the `__get__`/`__set__`-based design is about: The `ConfigParam` objects are assigned as attributes on the `config:TheanoConfigParser` variable and behave like properties.

I managed to refactor all the variables/function into methods on the `TheanoConfigParser`. This way, one can now do the following:

```python
with theano.config.change_flags(...):
    # do stuff

theano.config.get_config_hash()
theano.config.config_print(...)
```

For testing, it would be great to make all instances of `TheanoConfigParser` independent of one another (in contrast to the original singleton design) and orthogonalize the tests.
But because the properties are assigned to the type, this seems impossible unless we switch from property-based `theano.config.floatX` to something else. (For example `theano.config["floatX"]`, but possibly also attributes?).

I'm opening this as draft to get some early feedback. And also to see which tests fail..