### PR TITLE
Don't warn repeatedly for same un-optimize-able op.

### DIFF
--- a/theano/compile/debugmode.py
+++ b/theano/compile/debugmode.py
@@ -13,6 +13,7 @@ import sys
 from io import StringIO
 from itertools import chain
 from itertools import product as itertools_product
+from logging import Logger
 from warnings import warn
 
 import numpy as np
@@ -32,28 +33,11 @@ from theano.gof import graph, ops_with_inner_function
 from theano.gof.utils import MethodNotDefined
 from theano.link.basic import Container, LocalLinker
 from theano.link.utils import map_storage, raise_with_op
-from theano.utils import difference, get_unbound_function
+from theano.utils import NoDuplicateOptWarningFilter, difference, get_unbound_function
 
 
 __docformat__ = "restructuredtext en"
-_logger = logging.getLogger("theano.compile.debugmode")
-
-
-# Filter to avoid duplicating optimization warnings
-class NoDuplicateOptWarningFilter(logging.Filter):
-    prev_msgs = set()
-
-    def filter(self, record):
-        msg = record.getMessage()
-        if msg.startswith("Optimization Warning: "):
-            if msg in self.prev_msgs:
-                return False
-            else:
-                self.prev_msgs.add(msg)
-                return True
-        return True
-
-
+_logger: Logger = logging.getLogger("theano.compile.debugmode")
 _logger.addFilter(NoDuplicateOptWarningFilter())
 
 
@@ -538,7 +522,8 @@ def debugprint(
     if used_ids is None:
         used_ids = dict()
 
-    def get_id_str(obj, get_printed=True):
+    def get_id_str(obj, get_printed=True) -> str:
+        id_str: str = ""
         if obj in used_ids:
             id_str = used_ids[obj]
         elif obj == "output":

--- a/theano/tensor/opt.py
+++ b/theano/tensor/opt.py
@@ -102,12 +102,11 @@ from theano.tensor.type import (
     values_eq_approx_remove_inf_nan,
     values_eq_approx_remove_nan,
 )
-
-
-# import theano.tensor.basic as tt
+from theano.utils import NoDuplicateOptWarningFilter
 
 
 _logger = logging.getLogger("theano.tensor.opt")
+_logger.addFilter(NoDuplicateOptWarningFilter())
 
 
 def _fill_chain(new_out, orig_inputs):

--- a/theano/utils.py
+++ b/theano/utils.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import inspect
+import logging
 import os
 import struct
 import subprocess
@@ -25,6 +26,7 @@ __all__ = [
     "output_subprocess_Popen",
     "LOCAL_BITWIDTH",
     "PYTHON_INT_BITWIDTH",
+    "NoDuplicateOptWarningFilter",
 ]
 
 
@@ -374,3 +376,19 @@ def flatten(a):
         return l
     else:
         return [a]
+
+
+class NoDuplicateOptWarningFilter(logging.Filter):
+    """Filter to avoid duplicating optimization warnings."""
+
+    prev_msgs = set()
+
+    def filter(self, record):
+        msg = record.getMessage()
+        if msg.startswith("Optimization Warning: "):
+            if msg in self.prev_msgs:
+                return False
+            else:
+                self.prev_msgs.add(msg)
+                return True
+        return True


### PR DESCRIPTION
Fix for issue #23.

Keep a set of names of ops for which "can't optimize" warnings have already been issued. Check that set (and update it, if necessary) before issuing a warning to avoid warning floods.


**Thank your for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [relevant logical changes](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes).
+ [ ] There are tests covering the changes introduced in the PR.
+ [ ] Remove whitespace reformatting or factor into separate commit.
+ [ ] (Possibly) pull out repeated code into function.
