### PR TITLE
Add softmax to jaxify list

### DIFF
--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -743,6 +743,10 @@ def test_nnet():
     fgraph = theano.gof.FunctionGraph([x], [out])
     compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
 
+    out = tt.nnet.softmax(x)
+    fgraph = theano.gof.FunctionGraph([x], [out])
+    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+
 
 def test_tensor_basics():
     y = tt.vector("y")

--- a/theano/link/jax/jax_dispatch.py
+++ b/theano/link/jax/jax_dispatch.py
@@ -58,6 +58,7 @@ from theano.tensor.nlinalg import (
     QRFull,
     QRIncomplete,
 )
+from theano.tensor.nnet import Softmax
 from theano.tensor.nnet.sigm import ScalarSoftplus
 from theano.tensor.opt import MakeVector
 from theano.tensor.slinalg import Cholesky, Solve
@@ -248,6 +249,14 @@ def jax_funcify_Identity(op):
         return x
 
     return identity
+
+
+@jax_funcify.register(Softmax)
+def jax_funcify_Softmax(op):
+    def softmax(x):
+        return jax.nn.softmax(x)
+
+    return softmax
 
 
 @jax_funcify.register(ScalarSoftplus)


### PR DESCRIPTION
This PR adds the softmax function to the list of jaxified functions.  Should eventually fix https://github.com/pymc-devs/pymc3/issues/4358 once pymc3 bumps its theano version.