### PR TITLE
Fix pickleability of config

### DIFF
--- a/tests/compile/function/test_pfunc.py
+++ b/tests/compile/function/test_pfunc.py
@@ -7,6 +7,7 @@ from theano.compile.function import pfunc
 from theano.compile.io import In
 from theano.compile.sharedvalue import shared
 from theano.tensor import dmatrices, dmatrix, iscalar, lscalar
+from theano.utils import PYTHON_INT_BITWIDTH
 
 
 def data_of(s):
@@ -570,7 +571,7 @@ class TestPfunc:
     def test_default_updates_input(self):
         x = shared(0)
         y = shared(1)
-        if theano.configdefaults.python_int_bitwidth() == 32:
+        if PYTHON_INT_BITWIDTH == 32:
             a = iscalar("a")
         else:
             a = lscalar("a")

--- a/tests/compile/test_shared.py
+++ b/tests/compile/test_shared.py
@@ -4,12 +4,13 @@ import pytest
 import theano
 from theano.compile.sharedvalue import SharedVariable, generic, shared
 from theano.tensor import Tensor, TensorType
+from theano.utils import PYTHON_INT_BITWIDTH
 
 
 class TestSharedVariable:
     def test_ctors(self):
 
-        if theano.configdefaults.python_int_bitwidth() == 32:
+        if PYTHON_INT_BITWIDTH == 32:
             assert shared(7).type == theano.tensor.iscalar, shared(7).type
         else:
             assert shared(7).type == theano.tensor.lscalar, shared(7).type

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -201,6 +201,7 @@ from theano.tensor import (
     wvector,
     zvector,
 )
+from theano.utils import PYTHON_INT_BITWIDTH
 
 
 if config.mode == "FAST_COMPILE":
@@ -5587,7 +5588,7 @@ class TestArithmeticCast:
 
 class TestLongTensor:
     def test_fit_int64(self):
-        bitwidth = theano.configdefaults.python_int_bitwidth()
+        bitwidth = PYTHON_INT_BITWIDTH
         for exponent in range(bitwidth):
             val = 2 ** exponent - 1
             scalar_ct = constant(val)

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -36,6 +36,7 @@ from theano.tensor.extra_ops import (
     to_one_hot,
     unravel_index,
 )
+from theano.utils import LOCAL_BITWIDTH, PYTHON_INT_BITWIDTH
 
 
 def test_cpu_contiguous():
@@ -105,7 +106,7 @@ class TestSearchsortedOp(utt.InferShapeTester):
 
     def test_searchsortedOp_on_int_sorter(self):
         compatible_types = ("int8", "int16", "int32")
-        if theano.configdefaults.python_int_bitwidth() == 64:
+        if PYTHON_INT_BITWIDTH == 64:
             compatible_types += ("int64",)
         # 'uint8', 'uint16', 'uint32', 'uint64')
         for dtype in compatible_types:
@@ -420,10 +421,9 @@ class TestRepeatOp(utt.InferShapeTester):
         self.op = RepeatOp()
         # uint64 always fails
         # int64 and uint32 also fail if python int are 32-bit
-        ptr_bitwidth = theano.configdefaults.local_bitwidth()
-        if ptr_bitwidth == 64:
+        if LOCAL_BITWIDTH == 64:
             self.numpy_unsupported_dtypes = ("uint64",)
-        if ptr_bitwidth == 32:
+        if LOCAL_BITWIDTH == 32:
             self.numpy_unsupported_dtypes = ("uint32", "int64", "uint64")
 
     def test_repeatOp(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -242,16 +242,16 @@ def test_no_more_dotting():
 
 def test_mode_apply():
 
-    assert configdefaults.filter_mode("DebugMode") == "DebugMode"
+    assert configdefaults._filter_mode("DebugMode") == "DebugMode"
 
     with pytest.raises(ValueError, match="Expected one of"):
-        configdefaults.filter_mode("not_a_mode")
+        configdefaults._filter_mode("not_a_mode")
 
     # test with theano.Mode instance
     import theano.compile.mode
 
     assert (
-        configdefaults.filter_mode(theano.compile.mode.FAST_COMPILE)
+        configdefaults._filter_mode(theano.compile.mode.FAST_COMPILE)
         == theano.compile.mode.FAST_COMPILE
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Test config options."""
 import configparser as stdlib_configparser
+import io
+import pickle
 
 import pytest
 
@@ -254,6 +256,22 @@ def test_mode_apply():
         configdefaults._filter_mode(theano.compile.mode.FAST_COMPILE)
         == theano.compile.mode.FAST_COMPILE
     )
+
+
+def test_config_pickling():
+    # check that the real thing can be pickled
+    root = configdefaults.config
+    pickle.dump(root, io.BytesIO())
+
+    # and validate that the test would catch typical problems
+    root = _create_test_config()
+    root.add(
+        "test__lambda_kills_pickling",
+        "Lambda functions cause pickling problems.",
+        configparser.IntParam(5, lambda i: i > 0),
+    )
+    with pytest.raises(AttributeError, match="Can't pickle local object"):
+        pickle.dump(root, io.BytesIO())
 
 
 class TestConfigHelperFunctions:

--- a/theano/link/c/cmodule.py
+++ b/theano/link/c/cmodule.py
@@ -23,13 +23,13 @@ import numpy.distutils
 
 import theano
 from theano import config
-from theano.configdefaults import gcc_version_str, local_bitwidth
+from theano.configdefaults import gcc_version_str
 
 # we will abuse the lockfile mechanism when reading and writing the registry
 from theano.gof import compilelock
 from theano.gof.utils import flatten, hash_from_code
 from theano.link.c.exceptions import MissingGXX
-from theano.utils import output_subprocess_Popen, subprocess_Popen
+from theano.utils import LOCAL_BITWIDTH, output_subprocess_Popen, subprocess_Popen
 
 
 importlib = None
@@ -2308,7 +2308,7 @@ class GCC_compiler(Compiler):
         if not any(["arm" in flag for flag in cxxflags]) and not any(
             arch in platform.machine() for arch in ["arm", "aarch"]
         ):
-            n_bits = local_bitwidth()
+            n_bits = LOCAL_BITWIDTH
             cxxflags.append(f"-m{int(n_bits)}")
             _logger.debug(f"Compiling for {n_bits} bit architecture")
 
@@ -2317,7 +2317,7 @@ class GCC_compiler(Compiler):
             # '-fPIC ignored for target (all code is position independent)'
             cxxflags.append("-fPIC")
 
-        if sys.platform == "win32" and local_bitwidth() == 64:
+        if sys.platform == "win32" and LOCAL_BITWIDTH == 64:
             # Under 64-bit Windows installation, sys.platform is 'win32'.
             # We need to define MS_WIN64 for the preprocessor to be able to
             # link with libpython.

--- a/theano/tensor/extra_ops.py
+++ b/theano/tensor/extra_ops.py
@@ -13,6 +13,7 @@ from theano.gradient import (
 from theano.scalar import int32 as int_t
 from theano.scalar import upcast
 from theano.tensor import basic, nlinalg
+from theano.utils import LOCAL_BITWIDTH, PYTHON_INT_BITWIDTH
 
 
 class CpuContiguous(Op):
@@ -108,10 +109,7 @@ class SearchsortedOp(Op):
             return theano.Apply(self, [x, v], [out_type()])
         else:
             sorter = basic.as_tensor(sorter, ndim=1)
-            if (
-                theano.configdefaults.python_int_bitwidth() == 32
-                and sorter.dtype == "int64"
-            ):
+            if PYTHON_INT_BITWIDTH == 32 and sorter.dtype == "int64":
                 raise TypeError(
                     "numpy.searchsorted with Python 32bit do not support a"
                     " sorter of int64."
@@ -658,7 +656,7 @@ class RepeatOp(Op):
         # Some dtypes are not supported by numpy's implementation of repeat.
         # Until another one is available, we should fail at graph construction
         # time, not wait for execution.
-        ptr_bitwidth = theano.configdefaults.local_bitwidth()
+        ptr_bitwidth = LOCAL_BITWIDTH
         if ptr_bitwidth == 64:
             numpy_unsupported_dtypes = ("uint64",)
         if ptr_bitwidth == 32:

--- a/theano/utils.py
+++ b/theano/utils.py
@@ -3,6 +3,7 @@
 
 import inspect
 import os
+import struct
 import subprocess
 import sys
 import traceback
@@ -21,10 +22,33 @@ __all__ = [
     "subprocess_Popen",
     "call_subprocess_Popen",
     "output_subprocess_Popen",
+    "LOCAL_BITWIDTH",
+    "PYTHON_INT_BITWIDTH",
 ]
 
 
 __excepthooks = []
+
+
+LOCAL_BITWIDTH = struct.calcsize("P") * 8
+"""
+32 for 32bit arch, 64 for 64bit arch.
+By "architecture", we mean the size of memory pointers (size_t in C),
+*not* the size of long int, as it can be different.
+
+Note that according to Python documentation, `platform.architecture()` is
+not reliable on OS X with universal binaries.
+Also, sys.maxsize does not exist in Python < 2.6.
+'P' denotes a void*, and the size is expressed in bytes.
+"""
+
+PYTHON_INT_BITWIDTH = struct.calcsize("l") * 8
+"""
+The bit width of Python int (C long int).
+
+Note that it can be different from the size of a memory pointer.
+'l' denotes a C long int, and the size is expressed in bytes.
+"""
 
 
 def __call_excepthooks(type, value, trace):


### PR DESCRIPTION
I checked out the branch from https://github.com/pymc-devs/pymc3/pull/4382 to test pickleability of the config.
All locally defined functions and also `del param` were problematic.

I moved lambdas and local functions to the module level and prefixed them with `_`.

The bitwidth functions were a bit unnecessary. I placed them into `utils` as constants, because they just depend on the standard library.

closes #240

@kyleabeauchamp if you run into more incompatibilities, feel free to commit to this branch!