### PR TITLE
Clean up compiledir locking mechanism

### DIFF
--- a/bin/theano_cache.py
+++ b/bin/theano_cache.py
@@ -87,7 +87,7 @@ def main():
             cache = get_module_cache(init_args=dict(do_refresh=False))
             cache.clear_old()
         elif sys.argv[1] == "unlock":
-            theano.compile.compilelock.force_unlock()
+            theano.compile.compilelock.force_unlock(config.compiledir)
             print("Lock successfully removed!")
         elif sys.argv[1] == "purge":
             theano.compile.compiledir.compiledir_purge()

--- a/bin/theano_cache.py
+++ b/bin/theano_cache.py
@@ -14,7 +14,7 @@ if sys.platform == "win32":
     os.environ["THEANO_FLAGS"] = theano_flags
 
 import theano
-import theano.gof.compiledir
+import theano.compile.compiledir
 from theano import config
 from theano.link.c.basic import get_module_cache
 
@@ -81,16 +81,16 @@ def main():
                 )
                 _logger.debug(f"Remaining elements ({len(items)}): {', '.join(items)}")
         elif sys.argv[1] == "list":
-            theano.gof.compiledir.print_compiledir_content()
+            theano.compile.compiledir.print_compiledir_content()
         elif sys.argv[1] == "cleanup":
-            theano.gof.compiledir.cleanup()
+            theano.compile.compiledir.cleanup()
             cache = get_module_cache(init_args=dict(do_refresh=False))
             cache.clear_old()
         elif sys.argv[1] == "unlock":
-            theano.gof.compilelock.force_unlock()
+            theano.compile.compilelock.force_unlock()
             print("Lock successfully removed!")
         elif sys.argv[1] == "purge":
-            theano.gof.compiledir.compiledir_purge()
+            theano.compile.compiledir.compiledir_purge()
         elif sys.argv[1] == "basecompiledir":
             # Simply print the base_compiledir
             print(theano.config.base_compiledir)
@@ -98,9 +98,9 @@ def main():
             print_help(exit_status=1)
     elif len(sys.argv) == 3 and sys.argv[1] == "basecompiledir":
         if sys.argv[2] == "list":
-            theano.gof.compiledir.basecompiledir_ls()
+            theano.compile.compiledir.basecompiledir_ls()
         elif sys.argv[2] == "purge":
-            theano.gof.compiledir.basecompiledir_purge()
+            theano.compile.compiledir.basecompiledir_purge()
         else:
             print_help(exit_status=1)
     else:

--- a/doc/extending/pipeline.txt
+++ b/doc/extending/pipeline.txt
@@ -116,7 +116,7 @@ case if ``borrow`` was True, the thunk would be allowed to reuse (or
     crashes with paralell execution of some scripts). This mechanism is
     currently enabled by default, but if it causes any problem it may be
     disabled using the function
-    ``theano.gof.compilelock.set_lock_status(..)``.
+    ``theano.compile.compilelock.set_lock_status(..)``.
 
 Step 4 - Wrap the thunk in a pretty package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/extending/pipeline.txt
+++ b/doc/extending/pipeline.txt
@@ -111,12 +111,9 @@ case if ``borrow`` was True, the thunk would be allowed to reuse (or
     :attr:`config.blas__ldflags`, you will need to manually remove your compile cache,
     using ``Theano/bin/theano-cache clear``
 
-    Theano also implements a lock mechanism that prevents
-    multiple compilations within the same compilation directory (to avoid
-    crashes with paralell execution of some scripts). This mechanism is
-    currently enabled by default, but if it causes any problem it may be
-    disabled using the function
-    ``theano.compile.compilelock.set_lock_status(..)``.
+    Theano also implements a lock mechanism that prevents multiple compilations
+    within the same compilation directory (to avoid crashes with parallel
+    execution of some scripts).
 
 Step 4 - Wrap the thunk in a pretty package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,4 +122,3 @@ The thunk returned by the linker along with input and output
 containers is unwieldy. ``function`` hides that complexity away so
 that it can be used like a normal function with arguments and return
 values.
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -e ./
+filelock
 flake8==3.8.4
 pep8
 pyflakes

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         license=LICENSE,
         platforms=PLATFORMS,
         packages=find_packages(exclude=["tests.*"]),
-        install_requires=["numpy>=1.9.1", "scipy>=0.14"],
+        install_requires=["numpy>=1.9.1", "scipy>=0.14", "filelock"],
         package_data={
             "": [
                 "*.txt",

--- a/tests/compile/test_compilelock.py
+++ b/tests/compile/test_compilelock.py
@@ -1,0 +1,89 @@
+import multiprocessing
+import os
+import sys
+import tempfile
+
+import filelock
+import pytest
+
+from theano.compile.compilelock import force_unlock, local_mem, lock_ctx
+
+
+def test_compilelock_errors():
+    with tempfile.TemporaryDirectory() as dir:
+        with pytest.raises(ValueError):
+            with lock_ctx(dir, timeout=0):
+                pass
+        with pytest.raises(ValueError):
+            with lock_ctx(dir, timeout=-2):
+                pass
+
+
+def test_compilelock_force_unlock():
+    with tempfile.TemporaryDirectory() as dir_name:
+        with lock_ctx(dir_name):
+            dir_key = f"{dir_name}-{os.getpid()}"
+
+            assert dir_key in local_mem._locks
+            assert local_mem._locks[dir_key]
+
+            force_unlock(dir_name)
+
+            assert dir_key not in local_mem._locks
+
+            # A sub-process forcing unlock...
+            ctx = multiprocessing.get_context("spawn")
+            p = ctx.Process(target=force_unlock, args=(dir_name,))
+            p.start()
+            p.join()
+
+            assert dir_key not in local_mem._locks
+
+
+def check_is_locked(dir_name, q):
+    try:
+        with lock_ctx(dir_name, timeout=0.1):
+            q.put("unlocked")
+    except filelock.Timeout:
+        q.put("locked")
+
+
+def get_subprocess_lock_state(ctx, dir_name):
+    q = ctx.Queue()
+    p = ctx.Process(target=check_is_locked, args=(dir_name, q))
+    p.start()
+    result = q.get()
+    p.join()
+    return result
+
+
+def run_locking_test(ctx):
+
+    with tempfile.TemporaryDirectory() as dir_name:
+        assert get_subprocess_lock_state(ctx, dir_name) == "unlocked"
+
+        # create a lock on the test directory
+        with lock_ctx(dir_name):
+            dir_key = f"{dir_name}-{os.getpid()}"
+            assert dir_key in local_mem._locks
+            assert local_mem._locks[dir_key]
+
+            assert get_subprocess_lock_state(ctx, dir_name) == "locked"
+
+            with lock_ctx(dir_name, timeout=0.1):
+                assert get_subprocess_lock_state(ctx, dir_name) == "locked"
+
+            assert get_subprocess_lock_state(ctx, dir_name) == "locked"
+
+        assert get_subprocess_lock_state(ctx, dir_name) == "unlocked"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Fork is only available on linux")
+def test_locking_multiprocess_fork():
+    ctx = multiprocessing.get_context("fork")
+    run_locking_test(ctx)
+
+
+def test_locking_multiprocess_spawn():
+    ctx = multiprocessing.get_context("spawn")
+    run_locking_test(ctx)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -261,7 +261,18 @@ def test_mode_apply():
 def test_config_pickling():
     # check that the real thing can be pickled
     root = configdefaults.config
-    pickle.dump(root, io.BytesIO())
+    buffer = io.BytesIO()
+    pickle.dump(root, buffer)
+    # and also unpickled...
+    buffer.seek(0)
+    restored = pickle.load(buffer)
+    # ...without a change in the config values
+    for name in root._config_var_dict.keys():
+        v_original = getattr(root, name)
+        v_restored = getattr(restored, name)
+        assert (
+            v_restored == v_original
+        ), f"{name} did not survive pickling ({v_restored} != {v_original})"
 
     # and validate that the test would catch typical problems
     root = _create_test_config()

--- a/theano/compile/compiledir.py
+++ b/theano/compile/compiledir.py
@@ -1,3 +1,7 @@
+"""
+This module contains housekeeping functions for cleaning/purging the "compiledir".
+It is used by the "theano-cache" CLI tool, located in the /bin folder of the repository.
+"""
 import logging
 import os
 import pickle
@@ -10,7 +14,7 @@ from theano.configdefaults import config
 from theano.utils import flatten
 
 
-_logger = logging.getLogger("theano.gof.compiledir")
+_logger = logging.getLogger("theano.compile.compiledir")
 
 
 def cleanup():

--- a/theano/compile/compilelock.py
+++ b/theano/compile/compilelock.py
@@ -43,11 +43,10 @@ def force_unlock():
 
 
 @contextmanager
-def lock_ctx(lock_dir=None, keep_lock=False, **kw):
+def lock_ctx(lock_dir=None, **kw):
     get_lock(lock_dir=lock_dir, **kw)
     yield
-    if not keep_lock:
-        release_lock()
+    release_lock()
 
 
 # We define this name with an underscore so that python shutdown

--- a/theano/compile/compilelock.py
+++ b/theano/compile/compilelock.py
@@ -57,7 +57,7 @@ def lock_ctx(lock_dir: os.PathLike = None, *, timeout: typing.Optional[float] = 
         lock_dir = config.compiledir
     if timeout == -1:
         timeout = config.compile__timeout
-    elif timeout is not None or timeout <= 0:
+    elif not (timeout is None or timeout > 0):
         raise ValueError(f"Timeout parameter must be None or positive. Got {timeout}.")
 
     # locks are kept in a dictionary to account for changing compiledirs

--- a/theano/compile/compilelock.py
+++ b/theano/compile/compilelock.py
@@ -16,10 +16,7 @@ from theano.configdefaults import config
 
 __all__ = [
     "force_unlock",
-    "get_lock",
-    "lock",
     "lock_ctx",
-    "release_lock",
 ]
 
 

--- a/theano/compile/compilelock.py
+++ b/theano/compile/compilelock.py
@@ -2,14 +2,12 @@
 Locking mechanism to ensure no two compilations occur simultaneously
 in the same compilation directory (which can cause crashes).
 """
-import atexit
-import logging
 import os
-import socket
-import time
+import threading
+import typing
 from contextlib import contextmanager
 
-import numpy as np
+import filelock
 
 from theano.configdefaults import config
 
@@ -20,362 +18,61 @@ __all__ = [
 ]
 
 
-_random = np.random.RandomState([2015, 8, 2])
-
-_logger = logging.getLogger("theano.compile.compilelock")
-# If the user provided a logging level, we don't want to override it.
-if _logger.level == logging.NOTSET:
-    # INFO will show the "Refreshing lock" messages
-    _logger.setLevel(logging.INFO)
+local_mem = threading.local()
+local_mem._locks: typing.Dict[str, bool] = {}
 
 
-def force_unlock():
+def force_unlock(lock_dir: os.PathLike):
+    """Forces the release of the lock on a specific directory.
+
+    Parameters
+    ----------
+    lock_dir : os.PathLike
+        Path to a directory that was locked with `lock_ctx`.
     """
-    Delete the compilation lock if someone else has it.
 
-    """
-    get_lock(min_wait=0, max_wait=0.001, timeout=0)
-    release_lock()
+    fl = filelock.FileLock(os.path.join(lock_dir, ".lock"))
+    fl.release(force=True)
+
+    dir_key = f"{lock_dir}-{os.getpid()}"
+
+    if dir_key in local_mem._locks:
+        del local_mem._locks[dir_key]
 
 
 @contextmanager
-def lock_ctx(lock_dir=None, **kw):
-    get_lock(lock_dir=lock_dir, **kw)
-    yield
-    release_lock()
-
-
-# We define this name with an underscore so that python shutdown
-# deletes this before non-underscore names (like os).  We need to do
-# it this way to avoid errors on shutdown.
-def _get_lock(lock_dir=None, **kw):
-    """
-    Obtain lock on compilation directory.
+def lock_ctx(lock_dir: os.PathLike = None, *, timeout: typing.Optional[float] = -1):
+    """Context manager that wraps around FileLock and SoftFileLock from filelock package.
 
     Parameters
     ----------
-    kw
-        Additional arguments to be forwarded to the `lock` function when
-        acquiring the lock.
-
-    Notes
-    -----
-    We can lock only on 1 directory at a time.
-
+    lock_dir : str
+        A directory for which to acquire the lock.
+        Defaults to the config.compiledir.
+    timeout : float
+        Timeout in seconds for waiting in lock acquisition.
+        Defaults to config.compile__timeout.
     """
     if lock_dir is None:
-        lock_dir = os.path.join(config.compiledir, "lock_dir")
-    if not hasattr(get_lock, "n_lock"):
-        # Initialization.
-        get_lock.n_lock = 0
-        get_lock.lock_dir = lock_dir
-        get_lock.unlocker = Unlocker(get_lock.lock_dir)
-    else:
-        if lock_dir != get_lock.lock_dir:
-            # Compilation directory has changed.
-            # First ensure all old locks were released.
-            assert get_lock.n_lock == 0
-            # Update members for new compilation directory.
-            get_lock.lock_dir = lock_dir
-            get_lock.unlocker = Unlocker(get_lock.lock_dir)
-
-    # Only really try to acquire the lock if we do not have it already.
-    if get_lock.n_lock == 0:
-        lock(get_lock.lock_dir, **kw)
-        atexit.register(Unlocker.unlock, get_lock.unlocker)
-        # Store time at which the lock was set.
-        get_lock.start_time = time.time()
-    else:
-        # Check whether we need to 'refresh' the lock. We do this
-        # every 'config.compile__timeout / 2' seconds to ensure
-        # no one else tries to override our lock after their
-        # 'config.compile__timeout' timeout period.
-        if get_lock.start_time is None:
-            # This should not happen. So if this happen, clean up
-            # the lock state and raise an error.
-            while get_lock.n_lock > 0:
-                release_lock()
-            raise Exception(
-                "For some unknow reason, the lock was already "
-                "taken, but no start time was registered."
-            )
-        now = time.time()
-        if now - get_lock.start_time > config.compile__timeout / 2:
-            lockpath = os.path.join(get_lock.lock_dir, "lock")
-            _logger.info(f"Refreshing lock {lockpath}")
-            refresh_lock(lockpath)
-            get_lock.start_time = now
-    get_lock.n_lock += 1
-
-
-get_lock = _get_lock
-
-
-def release_lock():
-    """
-    Release lock on compilation directory.
-
-    """
-    get_lock.n_lock -= 1
-    assert get_lock.n_lock >= 0
-    # Only really release lock once all lock requests have ended.
-    if get_lock.n_lock == 0:
-        get_lock.start_time = None
-        get_lock.unlocker.unlock(force=False)
-
-
-# This is because None is a valid input for timeout
-notset = object()
-
-
-def lock(tmp_dir, timeout=notset, min_wait=None, max_wait=None, verbosity=1):
-    """
-    Obtain lock access by creating a given temporary directory (whose base will
-    be created if needed, but will not be deleted after the lock is removed).
-    If access is refused by the same lock owner during more than 'timeout'
-    seconds, then the current lock is overridden. If timeout is None, then no
-    timeout is performed.
-
-    The lock is performed by creating a 'lock' file in 'tmp_dir' that contains
-    a unique id identifying the owner of the lock (the process id, followed by
-    a random string).
-
-    When there is already a lock, the process sleeps for a random amount of
-    time between min_wait and max_wait seconds before trying again.
-
-    If 'verbosity' is >= 1, then a message will be displayed when we need to
-    wait for the lock. If it is set to a value >1, then this message will be
-    displayed each time we re-check for the presence of the lock. Otherwise it
-    is displayed only when we notice the lock's owner has changed.
-
-    Parameters
-    ----------
-    tmp_dir : str
-        Lock directory that will be created when acquiring the lock.
-    timeout : int or None
-        Time (in seconds) to wait before replacing an existing lock (default
-        config 'compile__timeout').
-    min_wait: int
-        Minimum time (in seconds) to wait before trying again to get the lock
-        (default config 'compile__wait').
-    max_wait: int
-        Maximum time (in seconds) to wait before trying again to get the lock
-        (default 2 * min_wait).
-    verbosity : int
-        Amount of feedback displayed to screen (default 1).
-
-    """
-    if min_wait is None:
-        min_wait = config.compile__wait
-    if max_wait is None:
-        max_wait = min_wait * 2
-    if timeout is notset:
+        lock_dir = config.compiledir
+    if timeout == -1:
         timeout = config.compile__timeout
-    # Create base of lock directory if required.
-    base_lock = os.path.dirname(tmp_dir)
-    if not os.path.isdir(base_lock):
+    elif timeout is not None or timeout <= 0:
+        raise ValueError(f"Timeout parameter must be None or positive. Got {timeout}.")
+
+    # locks are kept in a dictionary to account for changing compiledirs
+    dir_key = f"{lock_dir}-{os.getpid()}"
+
+    if dir_key not in local_mem._locks:
+        local_mem._locks[dir_key] = True
+        fl = filelock.FileLock(os.path.join(lock_dir, ".lock"))
+        fl.acquire(timeout=timeout)
         try:
-            os.makedirs(base_lock)
-        except OSError:
-            # Someone else was probably trying to create it at the same time.
-            # We wait two seconds just to make sure the following assert does
-            # not fail on some NFS systems.
-            time.sleep(2)
-    assert os.path.isdir(base_lock)
-
-    # Variable initialization.
-    lock_file = os.path.join(tmp_dir, "lock")
-    hostname = socket.gethostname()
-    my_pid = os.getpid()
-    no_display = verbosity == 0
-
-    nb_error = 0
-    # The number of time we sleep when their is no errors.
-    # Used to don't display it the first time to display it less frequently.
-    # And so don't get as much email about this!
-    nb_wait = 0
-    # Acquire lock.
-    while True:
-        try:
-            last_owner = "no_owner"
-            time_start = time.time()
-            other_dead = False
-            while os.path.isdir(tmp_dir):
-                try:
-                    with open(lock_file) as f:
-                        read_owner = f.readlines()[0].strip()
-
-                    # The try is transition code for old locks.
-                    # It may be removed when people have upgraded.
-                    try:
-                        other_host = read_owner.split("_")[2]
-                    except IndexError:
-                        other_host = ()  # make sure it isn't equal to any host
-                    if other_host == hostname:
-                        try:
-                            # Just check if the other process still exist.
-                            os.kill(int(read_owner.split("_")[0]), 0)
-                        except OSError:
-                            other_dead = True
-                        except AttributeError:
-                            pass  # os.kill does not exist on windows
-                except Exception:
-                    read_owner = "failure"
-                if other_dead:
-                    if not no_display:
-                        msg = f"process '{read_owner.split('_')[0]}'"
-                        _logger.warning(
-                            f"Overriding existing lock by dead {msg} "
-                            f"(I am process '{my_pid}')",
-                        )
-                    get_lock.unlocker.unlock(force=True)
-                    continue
-                if last_owner == read_owner:
-                    if timeout is not None and time.time() - time_start >= timeout:
-                        # Timeout exceeded or locking process dead.
-                        if not no_display:
-                            if read_owner == "failure":
-                                msg = "unknown process"
-                            else:
-                                msg = f"process '{read_owner.split('_')[0]}'"
-                            _logger.warning(
-                                f"Overriding existing lock by {msg} "
-                                f"(I am process '{my_pid}')",
-                            )
-                        get_lock.unlocker.unlock(force=True)
-                        continue
-                else:
-                    last_owner = read_owner
-                    time_start = time.time()
-                    no_display = verbosity == 0
-                if not no_display and nb_wait > 0:
-                    if read_owner == "failure":
-                        msg = "unknown process"
-                    else:
-                        msg = f"process '{read_owner.split('_')[0]}'"
-                    _logger.info(
-                        f"Waiting for existing lock by {msg} (I am "
-                        f"process '{my_pid}')",
-                    )
-                    _logger.info(f"To manually release the lock, delete {tmp_dir}")
-                    if verbosity <= 1:
-                        no_display = True
-                nb_wait += 1
-                time.sleep(_random.uniform(min_wait, max_wait))
-
-            try:
-                os.mkdir(tmp_dir)
-            except FileExistsError:
-                # Error while creating the directory: someone else
-                # must have tried at the exact same time.
-                nb_error += 1
-                if nb_error < 10:
-                    continue
-                else:
-                    raise
-            # Safety check: the directory should be here.
-            assert os.path.isdir(tmp_dir)
-
-            # Write own id into lock file.
-            unique_id = refresh_lock(lock_file)
-
-            # Verify we are really the lock owner (this should not be needed,
-            # but better be safe than sorry).
-            with open(lock_file) as f:
-                owner = f.readlines()[0].strip()
-
-            if owner != unique_id:
-                # Too bad, try again.
-                continue
-            else:
-                # We got the lock, hoorray!
-                return
-
-        except Exception as e:
-            # If something wrong happened, we try again.
-            _logger.warning(f"Something wrong happened: {type(e)} {e}")
-            nb_error += 1
-            if nb_error > 10:
-                raise
-            time.sleep(_random.uniform(min_wait, max_wait))
-            continue
-
-
-def refresh_lock(lock_file):
-    """
-    'Refresh' an existing lock by re-writing the file containing the owner's
-    unique id, using a new (randomly generated) id, which is also returned.
-
-    """
-    unique_id = "{}_{}_{}".format(
-        os.getpid(),
-        "".join([str(_random.randint(0, 9)) for i in range(10)]),
-        socket.gethostname(),
-    )
-    try:
-        with open(lock_file, "w") as lock_write:
-            lock_write.write(unique_id + "\n")
-    except Exception:
-        # In some strange case, this happen.  To prevent all tests
-        # from failing, we release the lock, but as there is a
-        # problem, we still keep the original exception.
-        # This way, only 1 test would fail.
-        while get_lock.n_lock > 0:
-            release_lock()
-        _logger.warning(
-            "Refreshing lock failed, we release the"
-            " lock before raising again the exception"
-        )
-        raise
-    return unique_id
-
-
-class Unlocker:
-    """
-    Class wrapper around release mechanism so that the lock is automatically
-    released when the program exits (even when crashing or being interrupted),
-    using the __del__ class method.
-
-    """
-
-    def __init__(self, tmp_dir):
-        self.tmp_dir = tmp_dir
-
-    def unlock(self, force=False):
-        """
-        Remove current lock.
-
-        This function does not crash if it is unable to properly
-        delete the lock file and directory. The reason is that it
-        should be allowed for multiple jobs running in parallel to
-        unlock the same directory at the same time (e.g. when reaching
-        their timeout limit).
-
-        """
-        # If any error occurs, we assume this is because someone else tried to
-        # unlock this directory at the same time.
-        # Note that it is important not to have both remove statements within
-        # the same try/except block. The reason is that while the attempt to
-        # remove the file may fail (e.g. because for some reason this file does
-        # not exist), we still want to try and remove the directory.
-
-        # Check if someone else didn't took our lock.
-        lock_file = os.path.join(self.tmp_dir, "lock")
-        if not force:
-            try:
-                with open(lock_file) as f:
-                    owner = f.readlines()[0].strip()
-                    pid, _, hname = owner.split("_")
-                    if pid != str(os.getpid()) or hname != socket.gethostname():
-                        return
-            except Exception:
-                pass
-
-        try:
-            os.remove(lock_file)
-        except Exception:
-            pass
-        try:
-            os.rmdir(self.tmp_dir)
-        except Exception:
-            pass
+            yield
+        finally:
+            if fl.is_locked:
+                fl.release()
+            if dir_key in local_mem._locks:
+                del local_mem._locks[dir_key]
+    else:
+        yield

--- a/theano/compile/function/types.py
+++ b/theano/compile/function/types.py
@@ -1361,7 +1361,7 @@ class FunctionMaker:
         # This function is not finished
         import os.path
 
-        from theano.gof.compilelock import get_lock, release_lock
+        from theano.compile.compilelock import get_lock, release_lock
 
         graph_db_file = os.path.join(config.compiledir, "optimized_graphs.pkl")
 

--- a/theano/link/c/basic.py
+++ b/theano/link/c/basic.py
@@ -11,9 +11,9 @@ from io import StringIO
 
 import numpy as np
 
+from theano.compile.compilelock import get_lock, release_lock
 from theano.configdefaults import config
 from theano.gof.callcache import CallCache
-from theano.gof.compilelock import get_lock, release_lock
 from theano.gof.graph import Constant, NoParams, io_toposort
 from theano.gof.graph import variables as get_variables
 from theano.gof.utils import MethodNotDefined

--- a/theano/link/c/basic.py
+++ b/theano/link/c/basic.py
@@ -1174,7 +1174,10 @@ class CLinker(Linker):
         return [r for r in uniq(ret) if r]
 
     def __compile__(
-        self, input_storage=None, output_storage=None, storage_map=None, keep_lock=False
+        self,
+        input_storage=None,
+        output_storage=None,
+        storage_map=None,
     ):
         """
         Compiles this linker's fgraph.
@@ -1216,7 +1219,6 @@ class CLinker(Linker):
             input_storage,
             output_storage,
             storage_map,
-            keep_lock=keep_lock,
         )
         return (
             thunk,
@@ -1248,9 +1250,7 @@ class CLinker(Linker):
             id += 2
         return init_tasks, tasks
 
-    def make_thunk(
-        self, input_storage=None, output_storage=None, storage_map=None, keep_lock=False
-    ):
+    def make_thunk(self, input_storage=None, output_storage=None, storage_map=None):
         """
         Compiles this linker's fgraph and returns a function to perform the
         computations, as well as lists of storage cells for both the inputs
@@ -1269,9 +1269,6 @@ class CLinker(Linker):
         storage_map: dict that map variables to storages.
             This is used when you need to customize the storage of
             this thunk
-        keep_lock:
-            If True, we won't release the lock on the compiledir
-            at the end of this function call.
         Returns: thunk, input_storage, output_storage
 
         The return values can be used as follows:
@@ -1283,7 +1280,7 @@ class CLinker(Linker):
         """
         init_tasks, tasks = self.get_init_tasks()
         cthunk, module, in_storage, out_storage, error_storage = self.__compile__(
-            input_storage, output_storage, storage_map, keep_lock=keep_lock
+            input_storage, output_storage, storage_map
         )
 
         res = _CThunk(cthunk, init_tasks, tasks, error_storage, module)
@@ -1685,9 +1682,7 @@ class CLinker(Linker):
             self._mod = mod
         return self._mod
 
-    def cthunk_factory(
-        self, error_storage, in_storage, out_storage, storage_map=None, keep_lock=False
-    ):
+    def cthunk_factory(self, error_storage, in_storage, out_storage, storage_map=None):
         """
         Returns a thunk that points to an instance of a C struct that
         can carry on the computation of this linker's fgraph
@@ -1715,9 +1710,7 @@ class CLinker(Linker):
             # Set compute_map as None as clinker do not support lazy evaluation
             for node in self.node_order:
                 node.op.prepare_node(node, storage_map, None, "c")
-            module = get_module_cache().module_from_key(
-                key=key, lnk=self, keep_lock=keep_lock
-            )
+            module = get_module_cache().module_from_key(key=key, lnk=self)
 
         vars = self.inputs + self.outputs + self.orphans
         # List of indices that should be ignored when passing the arguments

--- a/theano/link/c/cutils.py
+++ b/theano/link/c/cutils.py
@@ -2,8 +2,8 @@ import errno
 import os
 import sys
 
+from theano.compile.compilelock import get_lock, release_lock
 from theano.configdefaults import config
-from theano.gof.compilelock import get_lock, release_lock
 from theano.link.c import cmodule
 
 

--- a/theano/link/c/lazylinker_c.py
+++ b/theano/link/c/lazylinker_c.py
@@ -6,8 +6,8 @@ import warnings
 from importlib import reload
 
 import theano
+from theano.compile.compilelock import get_lock, release_lock
 from theano.configdefaults import config
-from theano.gof.compilelock import get_lock, release_lock
 from theano.link.c.cmodule import GCC_compiler
 
 

--- a/theano/link/c/lazylinker_c.py
+++ b/theano/link/c/lazylinker_c.py
@@ -6,7 +6,7 @@ import warnings
 from importlib import reload
 
 import theano
-from theano.compile.compilelock import get_lock, release_lock
+from theano.compile.compilelock import lock_ctx
 from theano.configdefaults import config
 from theano.link.c.cmodule import GCC_compiler
 
@@ -79,8 +79,7 @@ try:
                 f"Extra debug information: force_compile={force_compile}, _need_reload={_need_reload}"
             )
 except ImportError:
-    get_lock()
-    try:
+    with lock_ctx():
         # Maybe someone else already finished compiling it while we were
         # waiting for the lock?
         try:
@@ -152,9 +151,6 @@ except ImportError:
 
             assert lazylinker_ext._version == lazy_c.get_version()
             _logger.info(f"New version {lazylinker_ext._version}")
-    finally:
-        # Release lock on compilation directory.
-        release_lock()
 
 from lazylinker_ext.lazylinker_ext import *  # noqa
 

--- a/theano/scan/scan_perform_ext.py
+++ b/theano/scan/scan_perform_ext.py
@@ -17,8 +17,8 @@ from importlib import reload
 import numpy as np
 
 import theano
+from theano.compile.compilelock import get_lock, release_lock
 from theano.configdefaults import config
-from theano.gof.compilelock import get_lock, release_lock
 from theano.link.c import cmodule
 
 

--- a/theano/scan/scan_perform_ext.py
+++ b/theano/scan/scan_perform_ext.py
@@ -17,7 +17,7 @@ from importlib import reload
 import numpy as np
 
 import theano
-from theano.compile.compilelock import get_lock, release_lock
+from theano.compile.compilelock import lock_ctx
 from theano.configdefaults import config
 from theano.link.c import cmodule
 
@@ -50,8 +50,7 @@ try:
     if version != getattr(scan_perform, "_version", None):
         raise ImportError()
 except ImportError:
-    get_lock()
-    try:
+    with lock_ctx():
         # Maybe someone else already finished compiling it while we were
         # waiting for the lock?
         try:
@@ -139,9 +138,6 @@ except ImportError:
 
             assert scan_perform._version == scan_c.get_version()
             _logger.info(f"New version {scan_perform._version}")
-    finally:
-        # Release lock on compilation directory.
-        release_lock()
 
 # This is caused as cython use the old NumPy C-API but we use the new one.
 # To fix it completely, we would need to modify Cython to use the new API.


### PR DESCRIPTION
While orienting myself, I noticed that `theano.gof.compiledir` was not used anywhere.
I pushed this PR already to see if tests run through after its removal.