### PR TITLE
Rename and rearrange imports

### DIFF
--- a/theano/link/jax/jax_dispatch.py
+++ b/theano/link/jax/jax_dispatch.py
@@ -1,7 +1,5 @@
 from collections.abc import Sequence
-from functools import reduce
-from functools import singledispatch as dispatch
-from functools import update_wrapper
+from functools import reduce, singledispatch, update_wrapper
 from warnings import warn
 
 import jax
@@ -192,7 +190,7 @@ def compose_jax_funcs(out_node, fgraph_inputs, memo=None):
     return jax_funcs
 
 
-@dispatch
+@singledispatch
 def jax_funcify(op):
     """Create a JAX "perform" function for a Theano `Variable` and its `Op`."""
     raise NotImplementedError(f"No JAX conversion for the given `Op`: {op}")


### PR DESCRIPTION
Removing an unnecessary rename and rearranging some imports.

As for why I opened this PR, I did actually spend 5 minutes finding the docs for the `@dispatch` decorator before finding the import and seeing its been aliased. Even though its small I think it will help folks reading the codebase figure out what's going on a little faster.

Also saying this in light of this add docs issue Thomas opened.
https://github.com/pymc-devs/Theano-PyMC/issues/230

