### PR TITLE
Fix typo in normal RandomVariable's default arguments

### DIFF
--- a/theano/tensor/random/basic.py
+++ b/theano/tensor/random/basic.py
@@ -48,7 +48,7 @@ class NormalRV(RandomVariable):
     dtype = config.floatX
     _print_name = ("N", "\\operatorname{N}")
 
-    def __call__(self, loc=0.0, scale=1.1, size=None, **kwargs):
+    def __call__(self, loc=0.0, scale=1.0, size=None, **kwargs):
         return super().__call__(loc, scale, size=size, **kwargs)
 
 


### PR DESCRIPTION
This PR fixes a typo that sets the `normal` `RandomVariable`'s default scale to `1.1`.