### PR TITLE
Implement improved numerically-stable softplus

### DIFF
--- a/tests/tensor/nnet/test_sigm.py
+++ b/tests/tensor/nnet/test_sigm.py
@@ -110,6 +110,7 @@ class TestSoftplus:
 
     def test_elemwise(self):
         utt.verify_grad(softplus, [np.random.rand(3, 4)])
+        utt.verify_grad(softplus, [np.linspace(-40, 40, 20)])
 
 
 class TestSigmoidOpts:

--- a/tests/tensor/nnet/test_sigm.py
+++ b/tests/tensor/nnet/test_sigm.py
@@ -110,7 +110,13 @@ class TestSoftplus:
 
     def test_elemwise(self):
         utt.verify_grad(softplus, [np.random.rand(3, 4)])
-        utt.verify_grad(softplus, [np.linspace(-40, 40, 20)])
+
+    def test_accuracy(self):
+        # Test all aproximations are working (cutoff points are -37, 18, 33.3)
+        x_test = np.array([-40.0, -17.5, 17.5, 18.5, 40.0])
+        y_th = softplus(x_test).eval()
+        y_np = np.log1p(np.exp(x_test))
+        np.testing.assert_allclose(y_th, y_np, rtol=10e-10)
 
 
 class TestSigmoidOpts:

--- a/theano/tensor/nnet/sigm.py
+++ b/theano/tensor/nnet/sigm.py
@@ -348,22 +348,35 @@ theano.compile.optdb["uncanonicalize"].register(
 
 
 class ScalarSoftplus(scalar.UnaryScalarOp):
-    """
-    This helps numerical stability.
+    r"""
+    Compute log(1 + exp(x)), also known as softplus or log1pexp
+
+    This function is numerically more stable than the naive approach.
+
+    For details, see
+    https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
+
+    References
+        ----------
+        .. [Machler2012] Martin Mächler (2012).
+            "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr package"
     """
 
     @staticmethod
     def static_impl(x):
-        if x < -30.0:
-            return 0.0
-        if x > 30.0:
-            return x
         # If x is an int8 or uint8, numpy.exp will compute the result in
         # half-precision (float16), where we want float32.
-        x_dtype = str(getattr(x, "dtype", ""))
-        if x_dtype in ("int8", "uint8"):
-            return np.log1p(np.exp(x, sig="f"))
-        return np.log1p(np.exp(x))
+        not_int8 = str(getattr(x, "dtype", "")) not in ("int8", "uint8")
+        if x < -37.0:
+            return np.exp(x) if not_int8 else np.exp(x, signature="f")
+        elif x < 18.0:
+            return (
+                np.log1p(np.exp(x)) if not_int8 else np.log1p(np.exp(x, signature="f"))
+            )
+        elif x < 33.3:
+            return x + np.exp(-x) if not_int8 else x + np.exp(-x, signature="f")
+        else:
+            return x
 
     def impl(self, x):
         return ScalarSoftplus.static_impl(x)
@@ -378,11 +391,13 @@ class ScalarSoftplus(scalar.UnaryScalarOp):
         (z,) = out
         # These constants were obtained by looking at the output of
         # python commands like:
+        # import numpy, theano
+        # dt='float32'  # or float64
         #  for i in range(750):
         #      print i, repr(numpy.log1p(numpy.exp(_asarray([i,-i], dtype=dt))))
-        # the boundary checks prevent us from generating inf
+        # the upper boundary check prevents us from generating inf, whereas the
+        # the lower boundary check prevents using exp when the result will be 0 anyway
 
-        # float16 limits: -17.0, 6.0
         # We use the float32 limits for float16 for now as the
         # computation will happen in float32 anyway.
         if (
@@ -390,12 +405,28 @@ class ScalarSoftplus(scalar.UnaryScalarOp):
             or node.inputs[0].type == scalar.float16
         ):
             return (
-                """%(z)s = %(x)s < -103.0f ? 0.0 : %(x)s > 14.0f ? %(x)s : log1p(exp(%(x)s));"""
+                """
+                    %(z)s = (
+                        %(x)s < -103.0f ? 0.0 :
+                        %(x)s < -37.0f ? exp(%(x)s) :
+                        %(x)s < 18.0f ? log1p(exp(%(x)s)) :
+                        %(x)s < 33.3f ? %(x)s + exp(-%(x)s) :
+                        %(x)s
+                    );
+                    """
                 % locals()
             )
         elif node.inputs[0].type == scalar.float64:
             return (
-                """%(z)s = %(x)s < -745.0 ? 0.0 : %(x)s > 16.0 ? %(x)s : log1p(exp(%(x)s));"""
+                """
+                    %(z)s = (
+                        %(x)s < -745.0 ? 0.0 :
+                        %(x)s < -37.0 ? exp(%(x)s) :
+                        %(x)s < 18.0 ? log1p(exp(%(x)s)) :
+                        %(x)s < 33.3 ? %(x)s + exp(-%(x)s) :
+                        %(x)s
+                    );
+                    """
                 % locals()
             )
         else:

--- a/theano/tensor/nnet/sigm.py
+++ b/theano/tensor/nnet/sigm.py
@@ -357,9 +357,9 @@ class ScalarSoftplus(scalar.UnaryScalarOp):
     https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
 
     References
-        ----------
-        .. [Machler2012] Martin Mächler (2012).
-            "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr package"
+    ----------
+    .. [Machler2012] Martin Mächler (2012).
+        "Accurately computing `\log(1-\exp(- \mid a \mid))` Assessed by the Rmpfr package"
     """
 
     @staticmethod

--- a/theano/tensor/nnet/sigm.py
+++ b/theano/tensor/nnet/sigm.py
@@ -406,27 +406,27 @@ class ScalarSoftplus(scalar.UnaryScalarOp):
         ):
             return (
                 """
-                    %(z)s = (
-                        %(x)s < -103.0f ? 0.0 :
-                        %(x)s < -37.0f ? exp(%(x)s) :
-                        %(x)s < 18.0f ? log1p(exp(%(x)s)) :
-                        %(x)s < 33.3f ? %(x)s + exp(-%(x)s) :
-                        %(x)s
-                    );
-                    """
+                %(z)s = (
+                    %(x)s < -103.0f ? 0.0 :
+                    %(x)s < -37.0f ? exp(%(x)s) :
+                    %(x)s < 18.0f ? log1p(exp(%(x)s)) :
+                    %(x)s < 33.3f ? %(x)s + exp(-%(x)s) :
+                    %(x)s
+                );
+                """
                 % locals()
             )
         elif node.inputs[0].type == scalar.float64:
             return (
                 """
-                    %(z)s = (
-                        %(x)s < -745.0 ? 0.0 :
-                        %(x)s < -37.0 ? exp(%(x)s) :
-                        %(x)s < 18.0 ? log1p(exp(%(x)s)) :
-                        %(x)s < 33.3 ? %(x)s + exp(-%(x)s) :
-                        %(x)s
-                    );
-                    """
+                %(z)s = (
+                    %(x)s < -745.0 ? 0.0 :
+                    %(x)s < -37.0 ? exp(%(x)s) :
+                    %(x)s < 18.0 ? log1p(exp(%(x)s)) :
+                    %(x)s < 33.3 ? %(x)s + exp(-%(x)s) :
+                    %(x)s
+                );
+                """
                 % locals()
             )
         else:


### PR DESCRIPTION
This PR alters the Softplus Op to use the numerically stable approximation described by [Machler 2012](https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf).

It is also computationally efficient in that it uses safe and fast altenatives to the good default `log1p(exp(x))`:

1. `exp(x)` in the range `[-inf, -37]` (not used previously)
2. `log1p(exp(x))` in the range `[-37, 18]` (previously used in the range `[-30, 30]` in Python or `[-inf/underflow, 14/16]` in `c_code`)
2. `x + np.exp(-x)` in the range `[18, 33.3]` (not used previously)
3. `x` in the range `[33.3, +inf]` (previously used in the range `[30, +inf]` in Python or `[14/16, +inf]` in `c_code`)

The previous 64-bit `c_code` cutoff at `16.0` for when to use the approximation `log1p(x) = x` was a bit too eager (according to Machler, and my unittests below) and the rational for it was not clear either (the op was described as having the goal of numerical stabilization and not speedup). In addition, the Python version was not doing the same thing as the C counterpart.

According to my tests, there was no issue with the (also unexplained) 32-bit cutoff of `14.0`.

When it comes to unittests, the only thing that was checking for precision seems to have been the `TestSoftplus` in `test.sigm.py` via `verify_grad` which is not sensitive enough to detect the reduction in error introduced by this PR. It can, however, detect when very wrong cutoffs or obviously wrong approximations are used in the `c_code` so it is a good sanity check that the current PR is not breaking anything.

**Edit: Added specific accuracy unittests, which would fail with the previous 64-bit `c_code` implementation**

The 32bit wouldn't fail in the previous implementation due to its limited range, but I think it is better to keep the same implementation for simplicity sake. It is a bit more conservative/inefficient than needed, but not less accurate!

***

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.  If your commit description starts with "Fix...", then you're probably making this mistake.
+ [x] There are tests covering the changes introduced in the PR.

Closes #260 