### PR TITLE
Add filelock to conda dependency.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - scipy >=0.14.0
     - {{ pin_compatible('pygpu', '0.7', max_pin='0.8') }}   # [not osx]
     - jax  # [py>=37 and not win]
+    - filelock
 
 test:
   imports:


### PR DESCRIPTION
Conda-forge builds failed because of this.