### PR TITLE
Fix a bug involving thread local memory initialization

### DIFF
--- a/theano/compile/compilelock.py
+++ b/theano/compile/compilelock.py
@@ -18,8 +18,12 @@ __all__ = [
 ]
 
 
-local_mem = threading.local()
-local_mem._locks: typing.Dict[str, bool] = {}
+class ThreadFileLocks(threading.local):
+    def __init__(self):
+        self._locks = {}
+
+
+local_mem = ThreadFileLocks()
 
 
 def force_unlock(lock_dir: os.PathLike):


### PR DESCRIPTION
This PR fixes a bug that causes `lock_ctx` to access thread local memory `local_mem._threads` when it isn't initialized.